### PR TITLE
Capacitor 4 "Getting Started" pages

### DIFF
--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -6,13 +6,15 @@ slug: /getting-started/environment-setup
 
 # Environment Setup
 
-Capacitor has three officially supported application targets: Android, iOS, and Progressive Web Application (PWA). Additionally, you can use the community supported [Capacitor Electron](https://github.com/capacitor-community/electron) to make a desktop application with Capacitor.
+Capacitor has three officially supported application targets: Android, iOS, and Web. In order to create applications for all three platforms, you'll need to install all of the following dependencies. If you are not targeting one of the native mobile targets, you can skip the associated section.
 
-In order to create applications for all three platforms, you'll need to install all of the following dependencies. If you are not targeting one of the native mobile targets, you can skip the associated section.
+:::info
+Do you need to support Desktops? You can use Capacitor to build [Windows](https://ionic.io/docs/windows/usage) or [Electron](https://github.com/capacitor-community/electron) apps as well!
+:::
 
 ## Core Requirements
 
-In order to develop any application with Capacitor, you will need NodeJS 14 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta: a JavaScript tools manager](https://volta.sh/), or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
+In order to develop any application with Capacitor, you will need NodeJS 14 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
 
 Once you have installed Node, open your terminal of choice and type in the following command to make sure node is properly installed
 
@@ -21,7 +23,7 @@ node --version
 # v18.3.0
 ```
 
-With Node installed, you can get started with creating PWAs with Capacitor.
+With Node installed, you can get started with creating Progressive Web Applications (PWA) with Capacitor.
 
 ## iOS Requirements
 
@@ -31,6 +33,7 @@ In order to develop iOS applications using Capacitor, you will need three additi
 
 - Xcode
 - Xcode Command Line Tools
+- Homebrew
 - Cocoapods
 
 Once you've installed the core requirements, as well as Xcode, Xcode Command Line Tools, and Cocoapods, you'll be able to create both iOS applications and PWAs.
@@ -54,12 +57,55 @@ xcode-select -p
 # /Applications/Xcode.app/Contents/Developer
 ```
 
+### Homebrew
+
+Homebrew is a package manager for macOS package. You need to install it in order to install CocoaPods for both Intel and Apple Silicon Macs.
+
+To install Homebrew, run the following bash command:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+:::info
+Don't just trust us! This is how [brew.sh](https://brew.sh) recommends installing Homebrew.
+:::
+
+If you do not want to install Homebrew, alternative, but not recommended, instructions can be found below.
+
 ### CocoaPods
 
 Cocoapods is an iOS dependency manager that Capacitor uses to install and manage native dependencies for your iOS project. You can install [CocoaPods](https://cocoapods.org/) by running the following command in your terminal
 
 ```bash
+brew install cocoapods
+```
+
+You can verify that CocoaPods has installed correctly by running the following command.
+
+```bash
+pod --version
+# 1.11.3
+```
+
+#### Installing CocoaPods without Homebrew
+
+You can install CocoaPods directly with Ruby Gem. To install it, you can run the following command.
+```
 sudo gem install cocoapods
+```
+
+However, installing CocoaPods this way **will not** work on Apple Silicon Macs. You will need to run CocoaPods through Rosetta enabled. To do this, you can run the following commands.
+
+```bash
+sudo arch -x86_64 gem install ffi
+```
+
+Then, whenever you want to update your application to use a newer version of your web code, you will need to run the following commands.
+
+```bash
+npx cap copy
+arch -x86_64 pod install
 ```
 
 ## Android Requirements
@@ -69,13 +115,16 @@ In order to develop Android applications using Capacitor, you will need two addi
 - Android Studio
 - An Android SDK installation
 
+:::note
+You do not need to separately install the Java Development Kit (JDK). Android Studio
+will automatically install the proper JDK for you.
+:::
+
 Once you've installed the core requirements, as well as an Android SDK with Android Studio, you'll be able to create both Android applications and PWAs.
 
 ### Android Studio
 
 Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 4 requires a minimum of Android Studio 2020.1.
-
-**Note:** You _do not_ need to separately install the Java Development Kit (JDK) as it comes bundled with Android Studio.
 
 ### Android SDK
 

--- a/docs/main/getting-started/faqs.md
+++ b/docs/main/getting-started/faqs.md
@@ -1,0 +1,78 @@
+---
+title: Frequently Asked Questions
+description: Common Capacitor questions
+slug: /getting-started/faqs
+sidebar_label: FAQs
+---
+
+# FAQs
+
+Below are a list of commonly asked Capacitor questions. If you don't find an answer here, check out [our forum](https://forum.ionicframework.com) or [our Discord](https://ionic.link/discord). Check out the sidebar for a list of frequently asked questions 👉
+
+## What platforms does Capacitor support?
+
+Capacitor can target virtually any advice with our official and community platforms.
+
+### Official Platforms
+
+Capacitor officially supports the following platforms:
+- iOS 13+
+- Android 5.1+
+  - Requires Chrome WebView 60+
+- Modern Web Browsers
+  - Chrome
+  - Firefox
+  - Safari
+  - Edge
+- Windows 10+
+
+:::info
+Windows support requires a paid subscription. To get access to it, get in touch with [our sales team](https://ionic.io/contact/sales).
+:::
+
+### Community Platforms
+
+Capacitor also has community platforms to target cross platform desktop frameworks. The current community targets are the following.
+- Electron
+  - https://github.com/capacitor-community/electron
+- Tauri (alpha)
+  - https://github.com/capacitor-community/tauri
+
+
+## Do I need to use Ionic Framework with Capacitor?
+
+No! You don't! Capacitor works with **any** web application, not just ones built with other Ionic tools. If you want a specific look and feel for your Capacitor app, and Ionic Framework isn't the right UI toolkit for you, you shouldn't feel forced to use it. There are plenty of apps in both app stores that utilize Capacitor and not Ionic Framework.
+
+## Where can I find plugins for my Capacitor project?
+
+To find plugins for your project, you should check the following places in this order.
+
+### Capacitor Community GitHub ⚡
+
+The [Capacitor Community GitHub organization](https://github.com/capacitor-community) lists plugins that our excellent community of developers creates. They are Capacitor first plugins that are actively developed and should work in any Capacitor 3+ project. If you need a plugin, this should be one of the first places you look.
+
+### Awesome Capacitor 😎
+
+Like many other [Awesome lists](https://github.com/sindresorhus/awesome), [Awesome Capacitor](https://github.com/riderx/awesome-capacitor) is a community-curated list of great Capacitor plugins. If you can't find an official or community plugin, chances are that someone has already made the plugin you are looking for here.
+
+### Project Fugu 🐡
+
+[Project Fugu](https://www.chromium.org/teams/web-capabilities-fugu/) is the Chromium Team's [tracker](https://fugu-tracker.web.app/#shipped) of web APIs that have been added to Chromium browsers. While some features may not be supported on both Android and iOS, features like [Web Share](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API) and [ContactsManager (Android Only)](https://developer.mozilla.org/en-US/docs/Web/API/ContactsManager), may replace `@capacitor/share` or `@capacitor-community/contacts` for your use case.
+
+You can [Can I Use...?](https://caniuse.com) to check if you can use these features on Android and iOS _without_ needing any native plugins.
+
+### Cordova Plugins 🔌
+
+Did you know Capacitor supports Cordova plugins? If you are migrating off of Cordova, or have a Cordova plugin that doesn't have a Capacitor equivalent, you can use most Cordova plugins directly in Capacitor. You can [read our guide](https://capacitorjs.com/docs/plugins/cordova) on how to use Cordova plugins in Capacitor.
+
+## Can I build iOS apps without a Mac with Capacitor?
+
+Short answer, no. The longer answer is that while you can use cloud services like [Ionic AppFlow](https://ionic.io/appflow), you won't be able to test your application on a device or simulator. You should always be sure to test your application with a physical device to make sure that your Capacitor application is usable to people with Apple products.
+
+## Why do I get a blank screen when running on an Android emulator?
+
+Capacitor requires Android 5.1 as well as a WebView version of 60 or higher. If you create an Android 6 or 7 emulator for example, the newest version of the WebView won't be installed, and you'll get a blank white screen. To get around this, you can install a newer Android emulator for testing your application.
+
+## Why am I getting CocoaPods errors on my Apple Silicon Device?
+
+

--- a/docs/main/getting-started/installation.md
+++ b/docs/main/getting-started/installation.md
@@ -6,34 +6,43 @@ slug: /getting-started
 
 # Installing Capacitor
 
-This guide will help you install Capacitor into an existing frontend web app.
+There are two ways to create your Capacitor application. You can using the `@capacitor/create-app` package to create a Capacitor application from scratch, or you can add Capacitor to your already existing web project.
 
-> If starting a new app, we recommend using the documentation from your JavaScript framework of choice and then following this guide to integrate Capacitor.
->
-> You can also create a new basic app with `npm init @capacitor/app`.
+Remember to make sure your [environment is set up](/docs/getting-started/environment-setup) for the platforms you will be building for.
 
-Capacitor provides a native mobile runtime and API layer for web apps. It does not come with any specific set of UI controls. We recommend you use a mobile component framework (such as [Ionic Framework](https://ionicframework.com/)).
+## Creating a new Capacitor application
 
-## Before you start
-
-Make sure your [environment is set up](/docs/getting-started/environment-setup) for the platforms you will be building for.
-
-## Project Requirements
-
-Capacitor was designed to drop into any modern JavaScript web app. Projects must meet the following requirements:
-
-- Must have a `package.json` file.
-- Must have a separate directory for web assets.
-- Must have an `index.html` file with a `<head>` tag in the root of the web assets directory.
-
-## Adding Capacitor to your app
-
-In the root of your app, install Capacitor:
+The `@capacitor/create-app` package can be used to quickly create a Capacitor application. You can run the following command in an empty directory to scaffold a new Capacitor application.
 
 ```bash
-npm install @capacitor/core
-npm install @capacitor/cli --save-dev
+npm init @capacitor/app
 ```
+
+## Adding Capacitor to your existing web application
+
+Capacitor was designed to drop into any modern JavaScript web app. However, your project needs to have the following three requirements in order to use Capacitor with your existing application.
+
+Your project must have...
+
+- A `package.json` file
+- A separate directory for built web assets such as `dist` or `www`
+- An `index.html` file at the root of your web assets directory
+
+:::info
+Your `index.html` file must have a `<head>` tag in order to properly inject Capacitor. If you do not have a
+`<head>` in your Html, Capacitor plugins will not work.
+:::
+
+### Install Capacitor
+
+In the root of your app, install Capacitor's main npm depdencies: the core JavaScript runtime and the command line interface (CLI).
+
+```bash
+npm i @capacitor/core
+npm i -D @capacitor/cli
+```
+
+### Initialize your Capacitor config
 
 Then, initialize Capacitor using the CLI questionnaire:
 
@@ -41,11 +50,40 @@ Then, initialize Capacitor using the CLI questionnaire:
 npx cap init
 ```
 
-The CLI will ask you a few questions, starting with your app name, and the package id you would like to use for your app.
+The CLI will ask you a few questions, starting with your app name, and the package ID you would like to use for your app.
 
-> The `npx cap` command is how Capacitor is executed locally on the command-line in your project. [Learn more about the Capacitor CLI](/docs/cli).
+### Create your Android and iOS projects
+
+After the Capacitor core runtime is installed, you can install the Android and iOS platforms.
+
+```bash
+npm i @capacitor/android @capacitor/ios
+```
+
+Once the platforms have been added to your `package.json`, you can run the following commands to create your Android and iOS projects for your native application.
+
+```bash
+npx cap add android
+npx cap add ios
+```
+
+### Sync your web code to your native project
+
+Once you've created your native projects, you can sync your web application to your native project by running the following command.
+
+```bash
+npx cap sync
+```
+
+`npx cap sync` will copy your built web application, by default `www`, to your native project and install the native projects dependencies.
+
+:::info
+You can customize what folder is copied over by modifying the `webDir` variable in your [Capacitor Config](/docs/config) file that is created during `npx cap init`.
+:::
 
 ## Where to go next
+
+With your environment setup, and your project structure set up properly, you're ready to go! You can follow any of the links below if you need more specific documentation.
 
 [Get started with iOS &#8250;](/docs/ios)
 

--- a/docs/main/getting-started/with-ionic.md
+++ b/docs/main/getting-started/with-ionic.md
@@ -5,67 +5,55 @@ slug: /getting-started/with-ionic
 ---
 
 # Using Capacitor with Ionic Framework
+Capacitor can quickly be installed directly into any new or existing Ionic app by using the [Ionic CLI](https://ionicframework.com/docs/cli).
 
-## Installing
-
-Capacitor can be installed directly into any new or existing Ionic app.
-
-### New Ionic Project
-
-Capacitor is installed in new Ionic apps by default! All you have to do is start a new project:
+## Installing Capacitor in a new Ionic Project
+For new Ionic projects, Capacitor already installed in new Ionic apps by default! All you have to do is start a new project. To create a new Ionic project, run the following command:
 
 ```bash
 ionic start
 ```
 
-> If you'd like a tutorial for building your first Ionic/Capacitor app, see [this tutorial](https://ionicframework.com/docs/intro/next).
+If you'd like a tutorial for building your first Capacitor-based Ionic app, check out [this tutorial](https://ionicframework.com/docs/intro/next) by the Ionic Framework team.
 
-### Existing Ionic Project
-
-Install and initialize Capacitor with your app name and bundle ID:
+## Installing Capacitor to an existing Ionic Project
+If you have an existing Ionic project that doesn't have Capacitor enabled, you can enable Capacitor by running the following command.
 
 ```bash
 ionic integrations enable capacitor
 ```
 
-Ionic Framework makes use of the APIs in the following plugins:
+### Install Capacitor Plugin Dependencies
 
-- [**App**](/docs/apis/app)
-- [**Haptics**](/docs/apis/haptics)
-- [**Keyboard**](/docs/apis/keyboard)
-- [**StatusBar**](/docs/apis/status-bar)
+Ionic Framework makes use of the APIs in the following Capacitor plugins:
 
-For the best user experience, you should make sure these plugins are installed even if you don't import them in your app:
+- [`@capacitor/app`](/docs/plugins/apis/app)
+- [`@capacitor/haptics`](/docs/plugins/apis/haptics)
+- [`@capacitor/keyboard`](/docs/plugins/apis/keyboard)
+- [`@capacitor/status-bar`](/docs/plugins/apis/status-bar)
+
+For the best user experience, you should make sure these plugins are installed even if you don't import them in your app. To install these plugins, run the following command in the root of your project:
 
 ```bash
-npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
+npm i @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
 ```
-
-If your Ionic app uses Cordova, you will want to read the [Migrating from Cordova to Capacitor guide](/docs/cordova/migrating-from-cordova-to-capacitor) as well.
 
 ### Add Platforms
 
-After Capacitor installed, you can add native platforms to your app:
+After Capacitor installed and its plugins are installed, you can add mobile platforms to your app:
 
 ```bash
-ionic capacitor add
+ionic capacitor add android
+ionic capacitor add ios
 ```
 
 This will create a new directory in the root of your project for the native platform. This directory is a native project that should be considered a source artifact. Learn more about [native project management](/docs/cordova#native-project-management).
 
-## Workflow
+:::info
+If your Ionic app uses Cordova, we have a guide on how to [migrate from Cordova to Capacitor](/docs/cordova/migrating-from-cordova-to-capacitor) as well.
+:::
 
-### Build your Ionic App
-
-Capacitor JavaScript libraries are bundled into your app, so the web asset build is no different after Capacitor is installed.
-
-```bash
-ionic build
-```
-
-This creates the web asset directory that Capacitor copies into native projects, configured via `webDir` in the [Capacitor configuration](/docs/config).
-
-### Ionic CLI Capacitor Commands
+## Ionic CLI Capacitor Commands
 
 The Ionic CLI has a variety of high-level commands that wrap the Capacitor CLI for convenience. See the documentation for each below. Help output is also available by using the `--help` flag after each command.
 
@@ -75,4 +63,4 @@ The Ionic CLI has a variety of high-level commands that wrap the Capacitor CLI f
 - [`ionic capacitor sync`](https://ionicframework.com/docs/cli/commands/capacitor-sync)
 - [`ionic capacitor open`](https://ionicframework.com/docs/cli/commands/capacitor-open)
 
-[Learn more about development workflow in Capacitor &#8250;](/docs/basics/workflow)
+For more information on the Ionic CLI, and how to use it with Capacitor, you can see the documentation [here](https://ionicframework.com/docs/cli).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -211,10 +211,10 @@ module.exports = {
         sidebarPath: require.resolve('./sidebars.js'),
         editUrl: ({ versionDocsDirPath, docPath, locale }) => {
           if (locale != 'en') {
-            return 'https://crowdin.com/project/ionic-docs';
+            return 'https://crowdin.com/project/capacitor-docs';
           }
           if ((match = docPath.match(/api\/(.*)\.md/)) != null) {
-            return `https://github.com/ionic-team/ionic-docs/tree/main/docs/api/${match[1]}.md`;
+            return `https://github.com/ionic-team/capacitor-docs/tree/main/docs/api/${match[1]}.md`;
           }
           if ((match = docPath.match(/cli\/commands\/(.*)\.md/)) != null) {
             return `https://github.com/ionic-team/ionic-cli/edit/develop/packages/@ionic/cli/src/commands/${match[1].replace(
@@ -225,7 +225,7 @@ module.exports = {
           if ((match = docPath.match(/native\/(.*)\.md/)) != null) {
             return `https://github.com/ionic-team/ionic-native/edit/master/src/@awesome-cordova-plugins/plugins/${match[1]}/index.ts`;
           }
-          return `https://github.com/ionic-team/ionic-docs/edit/main/${versionDocsDirPath}/${docPath}`;
+          return `https://github.com/ionic-team/capacitor-docs/edit/main/${versionDocsDirPath}/${docPath}`;
         },
         exclude: ['README.md'],
         lastVersion: 'current',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ionic-docs",
+  "name": "capacitor-docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,7 +10,8 @@ module.exports = {
         'main/getting-started/installation',
         'main/getting-started/with-ionic',
         'main/getting-started/vscode-extension',
-        'main/getting-started/templates'
+        'main/getting-started/templates',
+        'main/getting-started/faqs'
       ],
     },
     {


### PR DESCRIPTION
Includes everything under the `docs/main/getting-started` folder and the "Getting Started" sidebar