### PR TITLE
Capacitor 4 "Basics" pages

### DIFF
--- a/docs/main/basics/configuring-your-app.md
+++ b/docs/main/basics/configuring-your-app.md
@@ -1,25 +1,20 @@
 ---
 title: Configuring Your App
 description: Native Project Configuration
-contributors:
-  - jcesarmobile
-  - dotNetkow
 slug: /basics/configuring-your-app
 ---
 
 # Configuring Your App
 
-Much of Capacitor is configured per-platform instead of in an abstracted system like Cordova's `config.xml`. This means that you will make most configuration changes in the native project using native tooling.
+Most of Capacitor is configured per-platform; meaning that you will make most configuration changes in the native project using native tooling.
 
-## Per-platform Management
+## Native Project Management
 
-Capacitor requires you to be more involved in the native project configuration than with Cordova. We think this approach makes it easy to follow existing iOS/Android guides, get help on Stack Overflow, and have complete control over your project.
+Configuring a Capacitor project is no different from configuring any iOS or Android project. Existing native developers  can easily work alongside web developers; with each side using the tools and SDKs they know best. While mobile application is a bit different than web development, we believe web developers can handle all the required native configuration on their own, and the Capacitor team provides documentation on things like how to deploy to [the Apple App Stores](/docs/ios/deploying-to-app-store) or [the Google Play Store](/docs/android/deploying-to-google-play) to help fill in knowledge gaps.
 
-Additionally, since configuring a Capacitor project is no different from configuring any iOS or Android project, existing native development teams can easily work alongside web developers, with each side using the tools and SDKs they are familiar with. Of course, we believe web developers can handle all the required native configuration on their own, and the Capacitor documentation exists to help web developers do just that.
+## Capacitor Configuration File
 
-## Capacitor Configuration
-
-Capacitor specific configuration is handled in the [Capacitor configuration file](/docs/config). These generally don't modify native functionality, but control Capacitor's tooling.
+Capacitor specific configuration is handled in the [Capacitor Configuration File](/docs/config). These generally don't modify native functionality, but control Capacitor's tooling. This config file includes things such as, setting the web directory to copy on `npx cap sync`, specifying the Android or iOS project folder, or setting the App ID/Name in your native project.
 
 ## Native Configuration
 

--- a/docs/main/basics/index.md
+++ b/docs/main/basics/index.md
@@ -1,3 +1,0 @@
-# Capacitor Basics
-
-Follow the links on the left to learn the basics of using and developing with Capacitor.

--- a/docs/main/basics/managing-platforms.md
+++ b/docs/main/basics/managing-platforms.md
@@ -1,3 +1,0 @@
-# Managing Deployment Platforms
-
-Capacitor supports iOS, Android, and PWA.

--- a/docs/main/basics/using-plugins.md
+++ b/docs/main/basics/using-plugins.md
@@ -1,26 +1,29 @@
 ---
 title: Using Plugins
 description: How to use plugins in Capacitor
-contributors:
-  - jcesarmobile
-  - dotNetkow
 slug: /basics/using-plugins
 ---
 
 # Using Plugins
 
-The Web View and the native app communicate through the use of Capacitor or Cordova plugins. Plugins provide native APIs such as camera, geolocation, and filesystem access to your web app.
+The WebView and the Capacitor runtime communicate through the use of **Capacitor Plugins**. Plugins provide access to native APIs such as camera, geolocation, and filesystem access in your web app.
 
 ## Capacitor Plugins
 
-The Capacitor team maintains [a set of Capacitor plugins](/docs/apis) for commonly used APIs. There is also a large set of Capacitor plugins available from [the Capacitor Community](https://github.com/capacitor-community/).
+The Capacitor team maintains [a set of Capacitor plugins](/docs/apis) for commonly used APIs. There is also a large set of Capacitor plugins available from [the Capacitor Community](https://github.com/capacitor-community/). If you have a suggestion for a Capacitor plugin, you can use [the Capacitor Community proposals repo](https://github.com/capacitor-community/proposals/).
 
 [Learn more about Capacitor plugins &#8250;](/docs/plugins)
 
+:::info
+Do you want to **make** Capacitor plugins? Browse the same proposal repo and try to make one [following our plugin creation guides](/docs/plugins/creating-plugin)!
+:::
+
 ## Cordova Plugins
 
-Though Capacitor plugins are preferred, Cordova plugins are an option. Capacitor has compatibility with most Cordova plugins, but there may be additional steps when installing them.
-
-> If you use a Cordova plugin because you weren't able to find a suitable Capacitor plugin, would you mind [creating a proposal for the Capacitor Community](https://github.com/capacitor-community/proposals/)?
+Can't find the exact Web API or Capacitor plugin for your project? Or maybe you're [migrating off of Cordova and onto Capacitor](/docs/cordova/migration-strategy)? Capacitor has a Cordova compatibility layer that attempts to mimic Cordova plugin functionality. Capacitor has compatibility with most Cordova plugins, but there may be additional steps when installing them.
 
 [Learn more about using Cordova plugins in Capacitor apps &#8250;](/docs/plugins/cordova)
+
+:::info
+If you use a Cordova plugin because you weren't able to find a suitable Capacitor plugin, would you mind [creating a proposal for the Capacitor Community](https://github.com/capacitor-community/proposals/)?
+:::

--- a/docs/main/basics/utilities.md
+++ b/docs/main/basics/utilities.md
@@ -1,74 +1,79 @@
 ---
-title: JavaScript Utilities
-description: Capacitor's JavaScript Utilities
-contributors:
-  - dotNetkow
+title: Capacitor's JavaScript API
+description: Capacitor's JavaScript API
 slug: /basics/utilities
+sidebar_label: JavaScript API
 ---
 
-# JavaScript Utilities
+# Capacitor's JavaScript API
 
-Capacitor has several JavaScript utilities useful for ensuring apps run successfully across multiple platforms with the same codebase. To use them, import Capacitor then call the desired utility function:
+Capacitor has several JavaScript functions available to ensure apps run successfully across multiple platforms with the same codebase.
+
+## The Global Capacitor object
+
+You can import the global Capacitor object with the following code:
 
 ```typescript
 import { Capacitor } from '@capacitor/core';
-const isAvailable = Capacitor.isPluginAvailable('Camera');
 ```
 
-## convertFileSrc
+The `Capacitor` object has several functions that help with the most common WebView to Native problems you may face when developing a Capacitor app.
+
+### Capacitor.convertFileSrc
 
 `convertFileSrc: (filePath: string) => string;`
 
-Convert a device filepath into a Web View-friendly path.
+Converts a device filepath into a Web View-friendly path.
 
 Capacitor apps are served on a different protocol than device files. To avoid difficulties between these protocols, paths to device files must be rewritten. For example, on Android, `file:///path/to/device/file` must be rewritten as `http://localhost/_capacitor_file_/path/to/device/file` before being used in the Web View.
 
 ```typescript
 // file:///path/to/device/photo.jpg
-const savedPhotoFile = await Filesystem.writeFile({
+const rawPhotoUri = await Filesystem.writeFile({
   path: "myFile.jpg",
   data: base64Data,
   directory: FilesystemDirectory.Data
 });
 
 // http://localhost/path/to/device/photo.jpg
-const savedPhoto = Capacitor.convertFileSrc(savedPhotoFile.uri),
-document.getElementById("savedPhoto").src = savedPhoto;
+const fixedPhotoUri = Capacitor.convertFileSrc(rawPhotoUri.uri),
 ```
 
-```html
-<img id="savedPhoto" />
-```
+### Capacitor.getPlatform
 
-## getPlatform
+`getPlatform: () => 'web' | 'ios' | 'android';`
 
-`getPlatform: () => string;`
-
-Get the name of the platform the app is currently running on: `web`, `ios`, `android`.
+Get the name of the Platform the app is currently running on. This will return a value of `"web"`, `"ios"`, or `"android"` depending on the device the app is running on.
 
 ```typescript
 if (Capacitor.getPlatform() === 'ios') {
-  // do something
+  console.log('iOS!');
+} else if (Capacitor.getPlatform() === 'android') {
+  console.log('Android!');
+} else {
+  console.log('Web!');
 }
 ```
 
-## isNativePlatform
+### Capacitor.isNativePlatform
 
 `isNativePlatform: () => boolean;`
 
-Check whether the currently running platform is native (`ios`, `android`).
+Check whether the currently running platform is native. This function returns a value of `true` if the app is running as a native, installed Capacitor app, or `false` if it is served via a browser or installed as a PWA.
 
 ```typescript
 if (Capacitor.isNativePlatform()) {
-  // do something
+  console.log("I'm a native app!");
+} else {
+  console.log("I'm a PWA or Web app!");
 }
 ```
 
-## isPluginAvailable
+### Capacitor.isPluginAvailable
 
 `isPluginAvailable: (name: string) => boolean;`
 
-Check if a plugin is available on the currently running platform. The plugin name is used in the plugin registry (e.g. `const { Name } = Plugins;`), which means it also works with custom plugins.
+Check if a plugin is available on the currently running platform. The plugin name is used in the plugin registry, which means it also works with custom plugins.
 
 ```typescript
 const isAvailable = Capacitor.isPluginAvailable('Camera');

--- a/docs/main/basics/workflow.md
+++ b/docs/main/basics/workflow.md
@@ -1,34 +1,20 @@
 ---
 title: Development Workflow
 description: Capacitor Workflow
-contributors:
-  - dotNetkow
-  - mlynch
 slug: /basics/workflow
 ---
 
 # Capacitor Workflow
 
-Working with Capacitor involves several key additions to your workflow.
+Working with Capacitor is slightly different than working with a traditional web app. To make your web native Capacitor application, you'll need to do the following steps.
 
-## Develop and build your Web App
+## Building your web code
 
-Capacitor turns your web app into a native binary for each platform. Thus, much of your work will consist of developing and then building a mobile-focused web app.
+Once you are ready to test your web app on a mobile device, you'll need to build your web app for distribution. If you are using a tool like [Create React App](https://create-react-app.dev/) or [Vite](https://vitejs.dev/) that command will be `npm build`; while a tool like [Angular](https://angular.io/) uses the command `ng build`. Whatever your command is, you will need to build your web code for distribution in order to use it with Capacitor.
 
-You will interact with the native platform underneath using Capacitor's plugins (such as [Camera](/docs/apis/camera)), or by using existing Cordova plugins with Capacitor's [Cordova Compatibility](/docs/cordova).
+## Syncing your web code to your Capacitor project
 
-To deploy your web app to native devices, you will first need to build the web assets into an output directory. Consult your JavaScript framework's documentation for the exact command. For most, it's `npm run build`.
-
-## Sync your Project
-
-You may wish to sync your web app with your native project(s) in the following circumstances:
-
-- When you want to copy web assets into your native project(s).
-- Before you run your project using a Native IDE.
-- After you install a new Capacitor plugin.
-- After you clone your project.
-- When you want to setup or reconfigure the native project(s) for Capacitor.
-- When you want to install native dependencies (e.g. with Gradle or CocoaPods).
+Once your web code has been built for distribution, you will need to push your web code to the web native Capacitor application. To do this, you can use the [Capacitor CLI](/docs/cli) to "sync" your web code and install/update the required native dependencies.
 
 To sync your project, run:
 
@@ -36,59 +22,70 @@ To sync your project, run:
 npx cap sync
 ```
 
-> If you get an error about not being able to find the web assets directory, you may need to configure `webDir` in the [Capacitor configuration](/docs/config).
+Running `npx cap sync` will **copy** over your already built web bundle to both your Android and iOS projects as well as **update** the native dependencies that Capacitor uses.
 
-[Learn more about `sync` &#8250;](/docs/cli/sync)
+You can [read our docs](/docs/cli/sync) on `sync` and more on the [Capacitor CLI reference](/docs/cli) documentation.
 
-## Run your Project
+:::info
+Did you get an error about "not being able to find the web assets directory?" Update your [Capacitor configuration](/docs/config) file to use the proper `webDir`.
+:::
 
-There are a few ways to deploy your project on native devices, depending on your use case. Most common is on the command-line with `npx cap run`.
 
-[Learn more about running your app on iOS &#8250;](/docs/ios#running-your-app)
+## Testing your Capacitor app
 
-[Learn more about running your app on Android &#8250;](/docs/android#running-your-app)
+Once you've synced over your web bundle to your native project, it is time to test your application on a mobile device. There are a few different ways to do this, but the easiest way is to use the built in Capacitor CLI commands.
 
-## Build your Project
+To run a debug build of your Capacitor app on an iOS device, you can run:
+```bash
+npx cap run ios
+```
 
-After you build your web assets (e.g. with `npm run build`) and copy them into your native project(s) with `npx cap sync`, you are ready to build a native binary.
+Similarly, to run a debug build of your Capacitor app on an Android device, you can run:
+```bash
+npx cap run android
+```
 
-Capacitor does not have a "build" command. After `sync`, you are encouraged to open your target platform's IDE for building your native app.
 
-For building your app on the command-line or in CI environments, you are encouraged to use your target platform's tooling: Gradle for Android and `xcodebuild` for iOS. Third-party tools such as [Fastlane](https://fastlane.tools) may make this easier. Cloud builds and more are available when using [Appflow](https://useappflow.com).
+Once you've iterated and tested your application, it is time to compile the final binary to distribute to other mobile devices.
 
-To see what the release process looks like for Capacitor, read the publishing guides for [iOS](/docs/ios/deploying-to-app-store) and [Android](/docs/android/deploying-to-google-play).
+:::info
+You can also [run your app on iOS via Xcode](/docs/ios#running-in-xcode) or [run your app on Android via Android Studio](/docs/android#running-with-android-studio) as well. Both options are valid for development. Go ahead and try both to see which option you prefer!
+:::
 
-## Open your Native IDE
+### Open your Native IDE
 
-You may wish to open your project in a Native IDE (e.g. Xcode and Android Studio) in the following circumstances:
+If you'd like more control over your native project you can quickly open the native IDEs using the Capacitor CLI.
 
-- When you want to run your project on a native device using the IDE.
-- When you want to debug native Java/Kotlin or Swift/Objective-C code.
-- When you want to work on the native side of your app.
-- When you want to compile a release build for the app store.
+To [open the iOS Capacitor `.xcworkspace` project in Xcode](/docs/ios#opening-the-ios-project), you can run:
+```bash
+npx cap open ios
+```
 
-[Learn more about opening your app in Xcode &#8250;](/docs/ios#opening-the-ios-project)
+Similarly, to [open the Android Capacitor project in Android Studio](/docs/android#opening-the-android-project), you can run:
+```bash
+npx cap open android
+```
 
-[Learn more about opening your app in Android Studio &#8250;](/docs/android#opening-the-android-project)
+Opening the native project can give you full control over the native runtime of your application. You can [create plugins](/docs/plugins), [add custom native code](/docs/ios/custom-code#custom-native-ios-code), or [compile your application](#compiling-your-native-binary) for releasing.
+
+## Compiling your native binary
+
+Capacitor does not have a `build` or `compile` command, nor will there ever be one. After `sync`, you are encouraged to open your target platform's IDE: Xcode for iOS or Android Studio for Android, for compiling your native app.
+
+To compile your app in a terminal or in CI environments, you can use `gradle` or `xcodebuild` directly. We also  suggest using tools such as [Fastlane](https://fastlane.tools) or a cloud build tool [Appflow](https://useappflow.com) to automate these processes for you. While every application is different, we have an example of a general release process for Capacitor projects. Go and read our publishing guides for [iOS](/docs/ios/deploying-to-app-store) and [Android](/docs/android/deploying-to-google-play) for more info on how to deploy to the Apple App Store or the Google Play Store.
 
 ## Updating Capacitor
 
-To update Capacitor Core and CLI:
+Updating your Capacitor runtime is as straightforward as runnin an `npm install`.
 
 ```bash
-npm install @capacitor/cli
-npm install @capacitor/core
+npm i @capacitor/core @capacitor/ios @capacitor/android
+npm i -D @capacitor/cli
 ```
 
-To update any or all of the platforms you are using:
+When updating Capacitor, you want to make sure your Core, Android, and iOS libraries are all the same version. Capacitor Core, Android, and iOS releases are all uploaded simultaneously, meaning that if you install all of the libraries at the same time, you'll be fine!
 
-```bash
-npm install @capacitor/ios
-npm install @capacitor/android
-```
+:::info
+You can subscribe to the [Capacitor repo](https://github.com/ionic-team/capacitor) to be notified of new releases. At the top of the repository index, click **Watch** -> **Releases only**.
+:::
 
-> You can subscribe to the [Capacitor repo](https://github.com/ionic-team/capacitor) to be notified of new releases. At the top of the repository index, click **Watch** -> **Releases only**.
-
-## Hooks
-
-Need to tie into the capacitor cli command events? Check out the [hooks here](/docs/cli/hooks).


### PR DESCRIPTION
Includes everything under the `docs/main/basics` folder and the "Basics" sidebar