### PR TITLE
remove whole touchesBegan

### DIFF
--- a/docs/main/updating/4-0.md
+++ b/docs/main/updating/4-0.md
@@ -27,16 +27,16 @@ platform :ios, '13.0'
 Remove unused `touchesBegan` method from `AppDelegate.swift`
 
 ```diff
-override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+-override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
 -  super.touchesBegan(touches, with: event)
-
-  let statusBarRect = UIApplication.shared.statusBarFrame
-  guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
-
-  if statusBarRect.contains(touchPoint) {
-      NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
-  }
-}
+-
+-  let statusBarRect = UIApplication.shared.statusBarFrame
+-  guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
+-
+-  if statusBarRect.contains(touchPoint) {
+-      NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
+-  }
+-}
 ```
 
 ## Android


### PR DESCRIPTION
The whole touchesBegan method should be removed, not just the super.touchesBegan(touches, with: event) call