### PR TITLE
docs(migration): Add some missing things

### DIFF
--- a/docs/main/updating/4-0.md
+++ b/docs/main/updating/4-0.md
@@ -20,10 +20,25 @@ The following guide describes how to upgrade your Capacitor 3 iOS project to Cap
 
 Do the following for your Xcode project: select the **Project** within the project editor and open the **Build Settings** tab. Under the **Deployment** section, change **iOS Deployment Target** to **iOS 13.0**. Repeat the same steps for any app **Targets**.
 
-Then, open `ios/App/Podfile` and update the iOS version to 13.0:
+Then, open `ios/App/Podfile` and follow these steps:
+1. Add this on the first line:
+
+```ruby
+require_relative '../../node_modules/@capacitor/ios/scripts/pods_helpers'
+```
+
+2. Update the iOS version to 13.0:
 
 ```ruby
 platform :ios, '13.0'
+```
+
+3. Add this block on the last line:
+
+```ruby
+post_install do |installer|
+  assertDeploymentTarget(installer)
+end
 ```
 
 ### Remove Unnecessary Code
@@ -61,7 +76,7 @@ The following guide describes how to upgrade your Capacitor 3 Android project to
 
 ### Update Android Project Variables
 
-In your `variables.gradle` file, update your values to the following new minimums
+In your `variables.gradle` file, update your values to the following new minimums and add  the new `coreSplashScreenVersion` and `androidxWebkitVersion`
 
 ```groovy
 minSdkVersion = 22
@@ -72,6 +87,8 @@ androidxAppCompatVersion = '1.4.2'
 androidxCoordinatorLayoutVersion = '1.2.0'
 androidxCoreVersion = '1.8.0'
 androidxFragmentVersion = '1.4.1'
+coreSplashScreenVersion = '1.0.0-rc01'
+androidxWebkitVersion = '1.4.0'
 junitVersion = '4.13.2'
 androidxJunitVersion = '1.1.3'
 androidxEspressoCoreVersion = '3.4.0'
@@ -99,7 +116,7 @@ In `android/build.gradle` file change `classpath 'com.google.gms:google-services
 
 ### Update to Gradle 7
 
-Adjust your Gradle project settings in `File > Project Structure > Project`. The Android Gradle Plugin Version should be 7.2.1 or later and the Gradle Version should be 7.3.3 or later. Apply these changes and run a gradle sync by clicking on the Elephant Icon in the top right of Android Studio
+Adjust your Gradle project settings in `File > Project Structure > Project`. The Android Gradle Plugin Version should be 7.2.1 or later and the Gradle Version should be 7.4.2 or later. Apply these changes and run a gradle sync by clicking on the Elephant Icon in the top right of Android Studio
 
 :::info
 Android Studio may provide an automatic migration to Gradle 7. Go ahead and take them up on the offer! To upgrade, go to your `build.gradle` file, and click on the 💡 icon, and click "Upgrade Gradle. Once your project is migrated over, run a gradle sync as described above.
@@ -138,9 +155,7 @@ To enable the new recommended **[Android 12 Splash Screen API](https://developer
 
 Not enabling the Android 12 Splash Screen will result in a double Splash Screen on Android 12+ devices and will use the old Splash Screen on older devices.
 
-These changes are optional but recommended to prevent Android Studio from showing `Cannot resolve symbol 'Theme.SplashScreen'` message after the previous change.
-
-- Add `coreSplashScreenVersion = '1.0.0-rc01'` to the `android/variables.gradle` file.
+This change is optional but recommended to prevent Android Studio from showing `Cannot resolve symbol 'Theme.SplashScreen'` message after the previous change.
 
 - Add `implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"` in the dependencies section of `android/app/build.gradle`.
 


### PR DESCRIPTION
Add the `post_install` step
Add the androidxWebkitVersion (reworked the variables section to also include coreSplashScreenVersion and removed it from the splash section)
Updated the gradle version to use the same the migrator sets
