### PR TITLE
docs(custom-code): Change reigsterPlugin order

### DIFF
--- a/docs/main/android/custom-code.md
+++ b/docs/main/android/custom-code.md
@@ -62,8 +62,8 @@ In your app's `MainActivity.java`, use `registerPlugin()` or `registerPlugins()`
  public class MainActivity extends BridgeActivity {
      @Override
      public void onCreate(Bundle savedInstanceState) {
-         super.onCreate(savedInstanceState);
 +        registerPlugin(EchoPlugin.class);
+         super.onCreate(savedInstanceState);
      }
  }
 ```

--- a/docs/main/updating/4-0.md
+++ b/docs/main/updating/4-0.md
@@ -141,6 +141,21 @@ From there, you can modify the "Gradle JDK" to be Java 11.
 Java 11 ships with the latest version of Android Studio. No additional downloads needed!
 :::
 
+### Change registerPlugin order
+
+If your app includes custom plugins built specifically for your application, you have to register them before `super.onCreate`:
+
+```diff-java
+ public class MainActivity extends BridgeActivity {
+     @Override
+     public void onCreate(Bundle savedInstanceState) {
++        registerPlugin(PluginInMyApp.class);
+         super.onCreate(savedInstanceState);
+-        registerPlugin(PluginInMyApp.class);
+     }
+ }
+```
+
 ### Optional: Use the new Android 12 Splash Screen API
 
 To enable the new recommended **[Android 12 Splash Screen API](https://developer.android.com/guide/topics/ui/splash-screen)** this change is required:

--- a/docs/plugins/tutorial/implementing-for-android.md
+++ b/docs/plugins/tutorial/implementing-for-android.md
@@ -59,11 +59,11 @@ import com.getcapacitor.BridgeActivity;
 import io.ionic.cap.plugin.plugins.ScreenOrientation.ScreenOrientationPlugin;
 
 public class MainActivity extends BridgeActivity {
-   @Override
-   public void onCreate(Bundle savedInstanceState) {
-       super.onCreate(savedInstanceState);
-       registerPlugin(ScreenOrientationPlugin.class);
-   }
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(ScreenOrientationPlugin.class);
+        super.onCreate(savedInstanceState);
+    }
 }
 ```
 


### PR DESCRIPTION
In Capacitor 4 `registerPlugin` should be called before `super.oncreate`, changed the 2 examples where it was being used and also added a step on the migration guide

closes https://github.com/ionic-team/capacitor-docs/issues/16