### PR TITLE
docs: Document minimun Android supported version

### DIFF
--- a/docs/main/android/index.md
+++ b/docs/main/android/index.md
@@ -16,7 +16,7 @@ Capacitor Android apps are configured and managed through Android Studio.
 
 ## Android Support
 
-API 21+ (Android 5 or later) is supported, which represents [over 95% of the Android market](https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide). Capacitor requires an Android WebView with Chrome version 60 or later. On Android 5 and 6, Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7+, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) is used.
+API 22+ (Android 5.1 or later) is supported, which represents [over 95% of the Android market](https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide). Capacitor requires an Android WebView with Chrome version 60 or later. On Android 5 and 6, Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7+, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) is used.
 
 ## Adding the Android Platform
 

--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -130,7 +130,7 @@ Android Studio is Google's IDE for creating native Android applications. You can
 
 Once Android Studio has been installed, you need to install an Android SDK package.
 
-Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 21 or greater.
+Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 22 or greater.
 
 In Android Studio, open **Tools -> SDK Manager** from the menu and install the platform versions you'd like to test with in the **SDK Platforms** tab:
 


### PR DESCRIPTION
Capacitor 4 supports API 22+ (Android 5.1+), update a few places where it still said 5.0 or 21