### PR TITLE
docs: Updating triggerJSEvent example and note regarding JSON data

### DIFF
--- a/docs/main/reference/core-apis/android.md
+++ b/docs/main/reference/core-apis/android.md
@@ -46,6 +46,8 @@ bridge.triggerJSEvent("myCustomEvent", "window");
 bridge.triggerJSEvent("myCustomEvent", "document", "{ 'dataKey': 'dataValue' }");
 ```
 
+Note: `data` must be a serialized JSON string value.
+
 ---
 
 ## Passing data

--- a/docs/main/reference/core-apis/ios.md
+++ b/docs/main/reference/core-apis/ios.md
@@ -74,8 +74,10 @@ Examples:
 
 ```swift
 bridge.triggerJSEvent(eventName: "myCustomEvent", target: "window")
-bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "my custom data")
+bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "{ 'dataKey': 'dataValue' }")
 ```
+
+Note: `data` must be a serialized JSON string value.
 
 ---
 

--- a/versioned_docs/version-v2/plugins/android.md
+++ b/versioned_docs/version-v2/plugins/android.md
@@ -253,6 +253,8 @@ window.addEventListener('myCustomEvent', function () {
 });
 ```
 
+Note: `data` must be a serialized JSON string value.
+
 #### Plugin Events
 
 Plugins can emit their own events that you can listen by attaching a listener to the plugin Object like this:

--- a/versioned_docs/version-v2/plugins/ios.md
+++ b/versioned_docs/version-v2/plugins/ios.md
@@ -155,17 +155,17 @@ Capacitor provides all this functions to fire events:
 //If you want to provide the target
 self.bridge.triggerJSEvent(eventName: "myCustomEvent", target: "window")
 
-self.bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "my custom data")
+self.bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "{ 'dataKey': 'dataValue' }")
 
 // Window Events
 self.bridge.triggerWindowJSEvent(eventName: "myCustomEvent")
 
-self.bridge.triggerWindowJSEvent(eventName: "myCustomEvent", data: "my custom data")
+self.bridge.triggerWindowJSEvent(eventName: "myCustomEvent", data: "{ 'dataKey': 'dataValue' }")
 
 // Document events
 self.bridge.triggerDocumentJSEvent(eventName: "myCustomEvent")
 
-self.bridge.triggerDocumentJSEvent(eventName: "myCustomEvent", data: "my custom data")
+self.bridge.triggerDocumentJSEvent(eventName: "myCustomEvent", data: "{ 'dataKey': 'dataValue' }")
 ```
 
 And to listen for it, just use regular javascript:
@@ -175,6 +175,8 @@ window.addEventListener('myCustomEvent', function () {
   console.log('myCustomEvent was fired');
 });
 ```
+
+Note: `data` must be a serialized JSON string value.
 
 #### Plugin Events
 

--- a/versioned_docs/version-v3/main/reference/core-apis/android.md
+++ b/versioned_docs/version-v3/main/reference/core-apis/android.md
@@ -46,6 +46,8 @@ bridge.triggerJSEvent("myCustomEvent", "window");
 bridge.triggerJSEvent("myCustomEvent", "document", "{ 'dataKey': 'dataValue' }");
 ```
 
+Note: `data` must be a serialized JSON string value.
+
 ---
 
 ## Passing data

--- a/versioned_docs/version-v3/main/reference/core-apis/ios.md
+++ b/versioned_docs/version-v3/main/reference/core-apis/ios.md
@@ -74,8 +74,10 @@ Examples:
 
 ```swift
 bridge.triggerJSEvent(eventName: "myCustomEvent", target: "window")
-bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "my custom data")
+bridge.triggerJSEvent(eventName: "myCustomEvent", target: "document", data: "{ 'dataKey': 'dataValue' }")
 ```
+
+Note: `data` must be a serialized JSON string value.
 
 ---
 


### PR DESCRIPTION
This change was missed with the docs migration
https://github.com/ionic-team/capacitor-site/pull/440

Added it for capacitor 2-3 docs too.