### PR TITLE
docs(ios): Fix link to deploying to app store

### DIFF
--- a/docs/main/ios/deploying-to-app-store.md
+++ b/docs/main/ios/deploying-to-app-store.md
@@ -3,7 +3,7 @@ title: Deploying to App Store
 description: How to deploy iOS Capacitor apps to the Apple App Store
 contributors:
   - mlynch
-slug: /ios/deplying-to-app-store
+slug: /ios/deploying-to-app-store
 ---
 
 # Deploying your Capacitor iOS App to the App Store

--- a/versioned_docs/version-v3/main/ios/deploying-to-app-store.md
+++ b/versioned_docs/version-v3/main/ios/deploying-to-app-store.md
@@ -3,7 +3,7 @@ title: Deploying to App Store
 description: How to deploy iOS Capacitor apps to the Apple App Store
 contributors:
   - mlynch
-slug: /ios/deplying-to-app-store
+slug: /ios/deploying-to-app-store
 ---
 
 # Deploying your Capacitor iOS App to the App Store


### PR DESCRIPTION
https://capacitorjs.com/docs/ios/deploying-to-app-store is broken because of a typo on the slug