### PR TITLE
fix: remove double v3 on versioned links

### DIFF
--- a/versioned_docs/version-v3/main/updating/3-0.md
+++ b/versioned_docs/version-v3/main/updating/3-0.md
@@ -430,17 +430,17 @@ A new `androidxCoordinatorLayoutVersion` variable is available, add it with valu
 
 The `androidxCoreVersion` can be updated to `1.3.2`.
 
-The `androidxMaterialVersion` variable was used by Action Sheet and Camera plugins, can be removed if not using them. If using them, check [Camera docs](https://capacitorjs.com/docs/v3/v3/apis/camera#variables) and [Action Sheet docs](https://capacitorjs.com/docs/v3/v3/apis/action-sheet#variables).
+The `androidxMaterialVersion` variable was used by Action Sheet and Camera plugins, can be removed if not using them. If using them, check [Camera docs](https://capacitorjs.com/docs/v3/apis/camera#variables) and [Action Sheet docs](https://capacitorjs.com/docs/v3/apis/action-sheet#variables).
 
-The `androidxBrowserVersion` variable was used by Browser plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/v3/apis/browser#variables).
+The `androidxBrowserVersion` variable was used by Browser plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/browser#variables).
 
 The `androidxLocalbroadcastmanagerVersion` variable can be removed.
 
-The `androidxExifInterfaceVersion` variable was used by Camera plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/v3/apis/camera#variables).
+The `androidxExifInterfaceVersion` variable was used by Camera plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/camera#variables).
 
-The `firebaseMessagingVersion` variable was used by Push Notifications plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/v3/apis/push-notifications#variables).
+The `firebaseMessagingVersion` variable was used by Push Notifications plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/push-notifications#variables).
 
-The `playServicesLocationVersion` variable was used by Geolocation plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/v3/apis/geolocation#variables).
+The `playServicesLocationVersion` variable was used by Geolocation plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/geolocation#variables).
 
 A new `androidxFragmentVersion` variable is available, add it with value `1.3.0`.
 

--- a/versioned_docs/version-v3/main/web/index.md
+++ b/versioned_docs/version-v3/main/web/index.md
@@ -31,7 +31,7 @@ Most commonly, apps will be using a framework with a build system that supports 
 
 To use the Capacitor runtime in a web app that is not using a build system or bundler/module loader, do the following:
 
-1. Set `bundledWebRuntime` to `true` in the [Capacitor configuration file](/docs/v3/v3/config)
+1. Set `bundledWebRuntime` to `true` in the [Capacitor configuration file](/docs/v3/config)
 
 ```json
 "bundledWebRuntime": true

--- a/versioned_docs/version-v3/plugins/creating-plugins/android-guide.md
+++ b/versioned_docs/version-v3/plugins/creating-plugins/android-guide.md
@@ -117,7 +117,7 @@ call.reject(exception.getLocalizedMessage(), null, exception);
 
 In most cases, a plugin method will get invoked to perform a task and can finish immediately. But there are situations where you will need to keep the plugin call available so it can be accessed later. You might want to do this to periodically return data such as streaming live geolocation data, or to perform an asynchronous task.
 
-See [this guide on saving plugin calls](/docs/v3/v3/core-apis/saving-calls) for more details on how to persist plugin calls.
+See [this guide on saving plugin calls](/docs/v3/core-apis/saving-calls) for more details on how to persist plugin calls.
 
 ### Running Code on Plugin Load
 

--- a/versioned_docs/version-v3/plugins/creating-plugins/ios-guide.md
+++ b/versioned_docs/version-v3/plugins/creating-plugins/ios-guide.md
@@ -264,7 +264,7 @@ let store = CNContactStore()
 
 In most cases, a plugin method will get invoked to perform a task and can finish immediately. But there are situations where you will need to keep the plugin call available so it can be accessed later. You might want to do this to periodically return data such as streaming live geolocation data, or to perform an asynchronous task.
 
-See [this guide on saving plugin calls](/docs/v3/v3/core-apis/saving-calls) for more details on how to persist plugin calls.
+See [this guide on saving plugin calls](/docs/v3/core-apis/saving-calls) for more details on how to persist plugin calls.
 
 ## Error Handling
 


### PR DESCRIPTION
There are a few urls with a double v3 on in on the v3 versioned docs that breaks the links they point to.

This PR removes one of the v3 to fix the links