### PR TITLE
docs: Remove init method on android upgrade

### DIFF
--- a/docs/main/updating/4-0.md
+++ b/docs/main/updating/4-0.md
@@ -141,6 +141,26 @@ From there, you can modify the "Gradle JDK" to be Java 11.
 Java 11 ships with the latest version of Android Studio. No additional downloads needed!
 :::
 
+### Switch to automatic Android plugin loading
+
+This was an optional change in Capacitor 3, but it's now mandatory for the Capacitor 4 upgrade since the init method has been removed. In `MainActivity.java`, the `onCreate` method can be removed. You no longer have to edit this file when adding or removing plugins installed via npm.
+
+```diff-java
+ public class MainActivity extends BridgeActivity {
+-    @Override
+-    public void onCreate(Bundle savedInstanceState) {
+-        super.onCreate(savedInstanceState);
+-
+-        // Initializes the Bridge
+-        this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
+-            // Additional plugins you've installed go here
+-            add(Plugin1.class);
+-            add(Plugin2.class);
+-        }});
+-    }
+ }
+```
+
 ### Change registerPlugin order
 
 If your app includes custom plugins built specifically for your application, you have to register them before `super.onCreate`:


### PR DESCRIPTION
Some users didn't do this step on the Capacitor 2 to 3 upgrade and now will fail to build if init method is still present, so add a step for removing it on the Capacitor 4 upgrade guide.