### PR TITLE
docs(app): update back button description

### DIFF
--- a/docs/apis/app.md
+++ b/docs/apis/app.md
@@ -106,8 +106,6 @@ exitApp() => Promise<void>
 Force exit the app. This should only be used in conjunction with the `backButton` handler for Android to
 exit the app when navigation is complete.
 
-Ionic handles this itself so you shouldn't need to call this if using Ionic.
-
 **Since:** 1.0.0
 
 --------------------


### PR DESCRIPTION
Ionic Framework does not automatically exit the application when on the root page. We encourage developers to implement this logic on a per-app basis: https://ionicframework.com/docs/developing/hardware-back-button#exiting-the-app