### PR TITLE
fix: use @latest-3 instead of @latest on capacitor 3 upgrade guide

### DIFF
--- a/docs/main/updating/3-0.md
+++ b/docs/main/updating/3-0.md
@@ -25,7 +25,7 @@ If you are using the Ionic CLI, official Capacitor 3 support starts at version 6
 ## Update Capacitor CLI and Core
 
 ```bash
-npm install @capacitor/cli@latest @capacitor/core@latest
+npm install @capacitor/cli@latest-3 @capacitor/core@latest-3
 ```
 
 ## ES2017+
@@ -234,7 +234,7 @@ In `ios/.gitignore`, change the ignore path from `App/public` to `App/App/public
 ### Update the Capacitor iOS platform
 
 ```bash
-npm install @capacitor/ios@latest
+npm install @capacitor/ios@latest-3
 npx cap sync ios
 ```
 
@@ -343,7 +343,7 @@ Capacitor 3 supports Android 5+ (and now supports Android 11). Android Studio 4+
 ### Update the Capacitor Android platform
 
 ```bash
-npm install @capacitor/android@latest
+npm install @capacitor/android@latest-3
 npx cap sync android
 ```
 


### PR DESCRIPTION
The 2.0-3.0 upgrade guide page currently instructs users to install the @latest tag of a few cap packages, which will pull 4.x now. Updated references to pull @latest-3 instead