### PR TITLE
docs(creating-plugins): mark "@latest"

### DIFF
--- a/docs/plugins/creating-plugins/overview.md
+++ b/docs/plugins/creating-plugins/overview.md
@@ -50,7 +50,7 @@ Ready to begin? Capacitor has [a plugin generator](https://github.com/ionic-team
 In a new terminal, run the following:
 
 ```bash
-npx init @capacitor/plugin@latest
+npm init @capacitor/plugin@latest
 ```
 
 The generator will prompt you for input. You can also supply command-line options (see the [GitHub repo](https://github.com/ionic-team/create-capacitor-plugin/)).

--- a/docs/plugins/creating-plugins/overview.md
+++ b/docs/plugins/creating-plugins/overview.md
@@ -50,7 +50,7 @@ Ready to begin? Capacitor has [a plugin generator](https://github.com/ionic-team
 In a new terminal, run the following:
 
 ```bash
-npm init @capacitor/plugin
+npx init @capacitor/plugin@latest
 ```
 
 The generator will prompt you for input. You can also supply command-line options (see the [GitHub repo](https://github.com/ionic-team/create-capacitor-plugin/)).


### PR DESCRIPTION
Adding the `@latest` tag to the plugin generator instructions. This will help ensure devs always start with the latest version.