### PR TITLE
fix: typo in environment-setup.md 

### DIFF
--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -27,7 +27,7 @@ With Node installed, you can get started with creating Progressive Web Applicati
 
 ## iOS Requirements
 
-To build iOS apps, you will need **macOS**. While there are solutions like [Ionic Appflow](http://ionicframework.com/appflow) that be used to perform iOS cloud builds if you don't have a Mac, it is highly recommended to have the tools available to you locally in order to properly test your Capacitor application.
+To build iOS apps, you will need **macOS**. While there are solutions like [Ionic Appflow](http://ionicframework.com/appflow) that can be used to perform iOS cloud builds if you don't have a Mac, it is highly recommended to have the tools available to you locally in order to properly test your Capacitor application.
 
 In order to develop iOS applications using Capacitor, you will need three additional dependencies:
 


### PR DESCRIPTION
adding the word "can" here makes it read more naturally