### PR TITLE
update: 'learn more about run' url

### DIFF
--- a/docs/main/android/index.md
+++ b/docs/main/android/index.md
@@ -56,7 +56,7 @@ To run the project on a device or emulator, run:
 npx cap run android
 ```
 
-The command will prompt you to select a target. [Learn more about `run`](/docs/cli/run).
+The command will prompt you to select a target. [Learn more about `run`](/docs/cli/commands/run).
 
 ### Running with Android Studio
 


### PR DESCRIPTION
As explain in title the url in documentation was wrong I just update it with the current location