### PR TITLE
doc(cli): add page for the cap build command and --inline option for cap copy

### DIFF
--- a/docs/cli/commands/build.md
+++ b/docs/cli/commands/build.md
@@ -1,0 +1,26 @@
+---
+title: CLI Command - cap build
+description: Capacitor CLI - cap build
+sidebar_label: build
+---
+
+# Capacitor CLI - cap build
+
+This command will build the native project to create a signed AAB, APK or IPA file. Build options can be specified on the command line or in your Capacitor Configuration File.
+
+```bash
+npx cap build [options] <platform>
+```
+
+<strong>Inputs:</strong>
+
+- `platform` (required): `android`, `ios`
+
+<strong>Options:</strong>
+
+- `--keystorepath <path>`: Path to the keystore file
+- `--keystorepass <keystore-password>`: Password to the keystore
+- `--keystorealias <alias>` - Key alias in the keystore
+- `--keystorealiaspass <alias-password>` - Password for the keystore alias
+- `--androidreleasetype <release-type>` - Can be either `AAB` or `APK`
+- `--scheme <scheme-to-build>` - iOS Scheme to build (default is App)

--- a/docs/cli/commands/copy.md
+++ b/docs/cli/commands/copy.md
@@ -18,6 +18,10 @@ npx cap copy [<platform>]
 
 - `platform` (optional): `android`, `ios`
 
+<strong>Options:</strong>
+
+- `--inline`: After syncing, all JS source maps will be inlined allowing for debugging an Android Web View in Chromium based browsers.
+
 ## Hooks
 
 The following hooks are available for copy command:


### PR DESCRIPTION
Document based on the PRs: 

- [feat(cli): add build command for android](https://github.com/ionic-team/capacitor/pull/5891)
- [feat(cli): add build command for ios](https://github.com/ionic-team/capacitor/pull/5925/files)
- [feat(cli): add inline option to copy command](https://github.com/ionic-team/capacitor/pull/5901)

