### PR TITLE
Update deep-links.md

### DIFF
--- a/docs/main/guides/deep-links.md
+++ b/docs/main/guides/deep-links.md
@@ -209,6 +209,7 @@ An example of the `apple-app-site-association` file is below. Be sure to replace
 ```json
 {
   "applinks": {
+    "apps": [],
     "details": [
       {
         "appID": "TEAMID.BUNDLEID",


### PR DESCRIPTION
The existing page leaves `"apps": []` out of the `apple-app-site-association`, which is listed as a required key according to this [documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html#//apple_ref/doc/uid/TP40016308-CH12-SW1) from Apple.