### PR TITLE
Update to latest tool, Capacitor Assets

### DIFF
--- a/docs/main/guides/splash-screens-and-icons.md
+++ b/docs/main/guides/splash-screens-and-icons.md
@@ -1,22 +1,23 @@
 ---
 title: Splash Screens and Icons
-description: Use cordova-res to generate resource images for native projects
+description: Use Capacitor Assets to generate resource images for native projects
 contributors:
   - dotNetkow
+  - indiebloom
 slug: /guides/splash-screens-and-icons
 ---
 
 # Creating Splash Screens and Icons
 
-Initial support for splash screen and icon generation is now available. For complete details, see the [cordova-res docs](https://github.com/ionic-team/cordova-res).
+Initial support for splash screen and icon generation is now available. For complete details, see [Capacitor Assets]([https://github.com/ionic-team/cordova-res](https://github.com/ionic-team/capacitor-assets)).
 
-First, install `cordova-res`:
+First, install `@capacitor/assets`:
 
 ```bash
-npm install -g cordova-res
+npm install @capacitor/assets
 ```
 
-`cordova-res` expects a Cordova-like structure: place one icon and one splash screen file in a top-level `resources` folder within your project, like so:
+`@capacitor/assets` expects a Cordova-like structure: place one icon and one splash screen file in a top-level `assets` or `resources` folder within your project, like so:
 
 ```
 resources/
@@ -27,6 +28,5 @@ resources/
 Next, run the following to generate all images then copy them into the native projects:
 
 ```bash
-cordova-res ios --skip-config --copy
-cordova-res android --skip-config --copy
+npx capacitor-assets generate
 ```


### PR DESCRIPTION
The link at the top of the the current version of this page now redirects to Capacitor Assets. Updating these docs to use that instead. It appears to be the supported version from here on out.