### PR TITLE
docs: update `FirebaseMessaging` pod

### DIFF
--- a/docs/main/guides/push-notifications-firebase.md
+++ b/docs/main/guides/push-notifications-firebase.md
@@ -299,13 +299,13 @@ To do this, we need to modify the `Podfile`, which can be found in Xcode under `
 
 ![Podfile Location iOS](../../../static/img/v4/docs/guides/firebase-push-notifications/podfile-location-ios.png)
 
-We need to add Firebase to the CocoaPods provided for our App target. To do that, add `pod Firebase/Messaging` to your `target 'App'` section, like so:
+We need to add Firebase to the CocoaPods provided for our App target. To do that, add `pod FirebaseMessaging` to your `target 'App'` section, like so:
 
 ```ruby
 target 'App' do
   capacitor_pods
   # Add your Pods here
-  pod 'Firebase/Messaging' # Add this line
+  pod 'FirebaseMessaging' # Add this line
 end
 ```
 
@@ -330,7 +330,7 @@ end
 target 'App' do
   capacitor_pods
   # Add your Pods here
-  pod 'Firebase/Messaging'
+  pod 'FirebaseMessaging'
 end
 
 post_install do |installer|

--- a/docs/main/guides/push-notifications-firebase.md
+++ b/docs/main/guides/push-notifications-firebase.md
@@ -355,7 +355,7 @@ To connect to Firebase when your iOS app starts up, you need to add the followin
 First, add an `import` at the top of the file:
 
 ```swift
-import Firebase
+import FirebaseCore
 ```
 
 ... and then add the configuration method for Firebase to initialization code to your `AppDelegate.swift` file, in the `application(didFinishLaunchingWithOptions)` method.
@@ -388,7 +388,7 @@ Your completed `AppDelegate.swift` file should look something like this:
 ```swift
 import UIKit
 import Capacitor
-import Firebase
+import FirebaseCore
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
From the official [Google docs](https://firebase.google.com/docs/ios/setup#available-pods):

> For apps that use CocoaPods, the Firebase pod is deprecated in v9.0 and higher. Instead, you need to reference product pods directly in your Podfile (for example, FirebaseCore instead of Firebase/Core and FirebaseFirestore instead of Firebase/Firestore). 