### PR TITLE
doc(faqs): remove Windows as an official platform

### DIFF
--- a/docs/main/getting-started/faqs.md
+++ b/docs/main/getting-started/faqs.md
@@ -24,11 +24,6 @@ Capacitor officially supports the following platforms:
   - Firefox
   - Safari
   - Edge
-- Windows 10+
-
-:::info
-Windows support requires a paid subscription. To get access to it, get in touch with [our sales team](https://ionic.io/contact/sales).
-:::
 
 ### Community Platforms
 


### PR DESCRIPTION
We no longer sell this, so we should not promote it as something we offer. We can always add it back later if we do start supporting it again at some point.

https://ionicteam.slack.com/archives/CERCH966L/p1676907128651719?thread_ts=1676906317.057429&cid=CERCH966L