### PR TITLE
Update deep-links.md

### DIFF
--- a/docs/main/guides/deep-links.md
+++ b/docs/main/guides/deep-links.md
@@ -333,7 +333,7 @@ Build then deploy the site.
 
 ### NuxtJS
 
-Place the association files under `static/.well-known`. No additional steps are necessary; simply build then deploy the site.
+Place the association files under `static/.well-known` (Nuxt 2) or `public/.well-known` (Nuxt 3). No additional steps are necessary; simply build then deploy the site.
 
 ### React
 


### PR DESCRIPTION
The "static" folder was functionally renamed to "public" in Nuxt v3.
https://nuxt.com/docs/guide/directory-structure/public