### PR TITLE
docs: fix typo on installation page

### DIFF
--- a/docs/main/getting-started/installation.md
+++ b/docs/main/getting-started/installation.md
@@ -33,7 +33,7 @@ Your `index.html` file must have a `<head>` tag in order to properly inject Capa
 
 ### Install Capacitor
 
-In the root of your app, install Capacitor's main npm depdencies: the core JavaScript runtime and the command line interface (CLI).
+In the root of your app, install Capacitor's main npm dependencies: the core JavaScript runtime and the command line interface (CLI).
 
 ```bash
 npm i @capacitor/core


### PR DESCRIPTION
Fixed typo:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/2801252/221197803-c93eca08-ce23-40b6-9c09-684f1f5935c3.png">
