### PR TITLE
Add note about `limitsNavigationsToAppBoundDomains` to cookies.md

### DIFF
--- a/docs/apis/cookies.md
+++ b/docs/apis/cookies.md
@@ -99,6 +99,8 @@ As of iOS 14, you cannot use 3rd party cookies by default. Add the following lin
 </array>
 ```
 
+Note that you may be required to update `ios.limitsNavigationsToAppBoundDomains` in your [configuration](https://capacitorjs.com/docs/config).
+
 ## API
 
 <docgen-index>


### PR DESCRIPTION
Hi there,

We recently added our `WKAppBoundDomains` as shown in the example [here](https://capacitorjs.com/docs/apis/cookies#third-party-cookies-on-ios). We were unaware this would result in `isNativePlatform` returning `false` on iOS until we finally discovered [this issue](https://github.com/ionic-team/capacitor/issues/4721). Could've saved us some headaches if this pointer was nearby, wanted to propose in case ya'll deem it beneficial for posterity.