### PR TITLE
docs: fixed some broken grammer. 

### DIFF
--- a/versioned_docs/version-v4/main/getting-started/environment-setup.md
+++ b/versioned_docs/version-v4/main/getting-started/environment-setup.md
@@ -71,7 +71,7 @@ To install Homebrew, run the following bash command:
 Don't just trust us! This is how [brew.sh](https://brew.sh) recommends installing Homebrew.
 :::
 
-If you do not want to install Homebrew, instructions can be found below for an alternative, however it is not recommended. 
+If you do not want to install Homebrew, instructions can be found below for an alternative; however, this is not recommended. 
 
 ### CocoaPods
 

--- a/versioned_docs/version-v4/main/getting-started/environment-setup.md
+++ b/versioned_docs/version-v4/main/getting-started/environment-setup.md
@@ -71,7 +71,7 @@ To install Homebrew, run the following bash command:
 Don't just trust us! This is how [brew.sh](https://brew.sh) recommends installing Homebrew.
 :::
 
-If you do not want to install Homebrew, alternative, but not recommended, instructions can be found below.
+If you do not want to install Homebrew, instructions can be found below for an alternative, however it is not recommended. 
 
 ### CocoaPods
 


### PR DESCRIPTION
> "If you do not want to install Homebrew, alternative, but not recommended, instructions can be found below." 

Seemed like broken english. It is possible that there is some reason it's phrased this way that I'm unaware of. But it annoyed me so I'm putting in a pull request.  