### PR TITLE
Add `The Push Notifications Guide for Capacitor` to Community Guides

### DIFF
--- a/versioned_docs/version-v4/main/guides/community.md
+++ b/versioned_docs/version-v4/main/guides/community.md
@@ -26,6 +26,8 @@ slug: /guides/community
 
 [Push Notifications: Using Push Notifications with Firebase in an Ionic Angular App](/docs/guides/push-notifications-firebase)
 
+[The Push Notifications Guide for Capacitor](https://capawesome.io/blog/the-push-notifications-guide-for-capacitor/)
+
 [Splash Screen: Creating a Dynamic/Adaptable Splash Screen for Capacitor (Android) &#8250;](https://www.joshmorony.com/creating-a-dynamic-universal-splash-screen-for-capacitor-android/)
 
 [Using the Capacitor Share API in IOS app &#8250;](https://akhromieiev.com/tutorials/using-the-capacitor-share-api-in-ios-app/)


### PR DESCRIPTION
I would like to add my new blog post [`The Push Notifications Guide for Capacitor`](https://capawesome.io/blog/the-push-notifications-guide-for-capacitor/) to the community guides.