### PR TITLE
docs: Add more migrate information

### DIFF
--- a/docs/main/updating/5-0.md
+++ b/docs/main/updating/5-0.md
@@ -55,7 +55,11 @@ Xcode 14 supports a single app icon of 1024x1024, so you can clean up your AppIc
 
 The following guide describes how to upgrade your Capacitor 4 Android project to Capacitor 5.
 
-Android Studio can assist with some of the updates related to gradle and moving package into build files.  To start, run `Tools -> AGP Upgrade Assistant`.
+### Upgrade Android Studio
+
+Capacitor 5 requires Android Studio Flamingo | 2022.2.1 or newer because of the usage of Gradle 8, that requires Java JDK 17. Java 17 ships with Android Studio Flamingo. No additional downloads needed!
+
+Once it's updated, Android Studio can assist with some of the updates related to gradle and moving package into build files.  To start, run `Tools -> AGP Upgrade Assistant`.
 
 ![APG Upgrade Assistant](../../../static/img/v5/docs/android/agp-upgrade-assistant.png)
 
@@ -91,18 +95,18 @@ cordovaAndroidVersion = '10.1.1'
 
 ```
 
-### Update gradle plugin to 7.4.1
+### Update gradle plugin to 8.0.0
 
 ```diff
 # build.gradle
 
     dependencies {
 -       classpath 'com.android.tools.build:gradle:7.2.1'
-+       classpath 'com.android.tools.build:gradle:7.4.1'
++       classpath 'com.android.tools.build:gradle:8.0.0'
 
 ```
 
-### Update gradle wrapper to 7.5
+### Update gradle wrapper to 8.0.2
 
 ```diff
 # gradle-wrapper.properties
@@ -110,7 +114,7 @@ cordovaAndroidVersion = '10.1.1'
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 - distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
-+ distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
++ distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 ```
@@ -152,13 +156,18 @@ In Capacitor 6, `https` is going to be the default setting for `androidScheme` f
 
 Changing the scheme is the equivalent to shipping your application on a different domain, which means any data stored in in cookies, localstorage, etc would no longer be accessible. To avoid data loss as a result of this change, you should set the scheme to `http` now even if it's the current default.
 
-```json
+```typescript
 {
   server: {
     androidScheme: "http"
   }
 }
 ```
+
+### Update kotlin version
+
+If your project is using kotlin, update the `kotlin_version` variable to `'1.8.20'`.
+
 
 ## Plugins
 

--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -48,16 +48,16 @@ ext {
 +   androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
 ```
 
-### Update gradle plugin to 7.4.1
+### Update gradle plugin to 8.0.0
 
 ```diff
     dependencies {
 -       classpath 'com.android.tools.build:gradle:7.2.1'
-+       classpath 'com.android.tools.build:gradle:7.4.1'
++       classpath 'com.android.tools.build:gradle:8.0.0'
     }
 ```
 
-### Update gradle wrapper to 7.5
+### Update gradle wrapper to 8.0.2
 
 ```diff
 # gradle-wrapper.properties
@@ -65,7 +65,7 @@ ext {
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 - distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
-+ distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
++ distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 ```


### PR DESCRIPTION
Add step about Android Studio Flamingo requirement, kotlin version, gradle/AGP 8