### PR TITLE
docs: Update nodeJS information

### DIFF
--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -14,7 +14,7 @@ Do you need to support Desktops? You can use Capacitor to build [Windows](https:
 
 ## Core Requirements
 
-In order to develop any application with Capacitor, you will need NodeJS 14 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
+In order to develop any application with Capacitor, you will need NodeJS 16 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
 
 Once you have installed Node, open your terminal of choice and type in the following command to make sure node is properly installed
 

--- a/docs/main/updating/5-0.md
+++ b/docs/main/updating/5-0.md
@@ -8,6 +8,10 @@ slug: /updating/5-0
 
 Compared to previous upgrades, the breaking changes between Capacitor 4 and 5 are extremely minimal. In this guide, you'll find steps to update your project to the current Capacitor 5 version as well as a list of breaking changes for our official plugins.
 
+## NodeJS 16+
+
+Node 12 has reached end-of-life. Node 14 will reach end-of-life on April 30th, 2023. Capacitor 5 requires NodeJS 16 or greater. (Latest LTS version is recommended.)
+
 ## Using the CLI to Migrate
 
 Install the `next` version of the Capacitor CLI to your project:

--- a/versioned_docs/version-v4/main/getting-started/environment-setup.md
+++ b/versioned_docs/version-v4/main/getting-started/environment-setup.md
@@ -14,7 +14,7 @@ Do you need to support Desktops? You can use Capacitor to build [Windows](https:
 
 ## Core Requirements
 
-In order to develop any application with Capacitor, you will need NodeJS 14 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
+In order to develop any application with Capacitor, you will need NodeJS 12 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
 
 Once you have installed Node, open your terminal of choice and type in the following command to make sure node is properly installed
 


### PR DESCRIPTION
Update Capacitor 4 requirements as node 12 is still supported there.
Update Capacitor 5 requirements to indicate that node 16 is required
Update Capacitor 5 migrate guide to indicate that node 16 is required