### PR TITLE
docs: Add information about plugin migration tool

### DIFF
--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -123,3 +123,15 @@ compileOptions {
 +    targetCompatibility JavaVersion.VERSION_17
 }
 ```
+
+### Update kotlin_version
+
+If your plugin uses kotlin, update the default `kotlin_version`
+
+```diff
+# build.gradle
+buildscript {
+-    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.7.0'
++    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.8.20'
+    repositories {
+```

--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -135,3 +135,13 @@ buildscript {
 +    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.8.20'
     repositories {
 ```
+
+And replace `org.jetbrains.kotlin:kotlin-stdlib-jdk7` or `org.jetbrains.kotlin:kotlin-stdlib-jdk8` dependencies with `org.jetbrains.kotlin:kotlin-stdlib`.
+
+
+```diff
+# build.gradle
+dependencies {
+-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
++    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+```

--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -25,7 +25,7 @@ To match iOS behavior, `PluginCall.getObject()` and `PluginCall.getArray()` on A
 
 ## Using @capacitor/plugin-migration-v4-to-v5
 
-From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5` and it will perform all the file changes automatically.
+From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5@latest` and it will perform all the file changes automatically.
 
 ## Updating the files manually
 

--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -4,7 +4,7 @@ description: Guide for updating Capacitor from earlier versions to v5 in your pl
 slug: /updating/plugins/5-0
 ---
 
-# Updating Capacitor to 5.0 in your plugin
+# Breaking changes in code
 
 ## iOS
 ### Changes to CAPBridgedPlugin protocol
@@ -15,9 +15,23 @@ slug: /updating/plugins/5-0
  
 The vast majority of users should not experience any issues since the status quo is to use the macro to generate conformance to `CAPBridgedPlugin`. Any users who cast to `CAPBridgedPlugin` to or manually conform to `CAPBridgedPlugin` without the macro will be affected.
 
-
-
 ## Android
+
+### PluginCall.getObject() / PluginCall.getArray()
+
+To match iOS behavior, `PluginCall.getObject()` and `PluginCall.getArray()` on Android can now return null.  We recommend plugin authors to perform null checks around code handling returns from either of these methods.
+
+# Updating Capacitor to 5.0 in your plugin
+
+## Using @capacitor/plugin-migration-v4-to-v5
+
+From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5` and it will perform all the file changes automatically.
+
+## Updating the files manually
+
+### Updating package.json
+
+Update `@capacitor/cli`, `@capacitor/core`, `@capacitor/android` and `@capacitor/ios` to `next` version.
 
 ### Updating targetSDK / compileSDK to 33
 ```diff
@@ -29,9 +43,6 @@ android {
 -    targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 32
 +    targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
 ```
-
-### PluginCall.getObject() / PluginCall.getArray()
-To match iOS behavior, `PluginCall.getObject()` and `PluginCall.getArray()` on Android can now return null.  We recommend plugin authors to perform null checks around code handling returns from either of these methods.
 
 ### Update Android Plugin Variables
 
@@ -99,4 +110,16 @@ android {
 android.useAndroidX=true
 - # Automatically convert third-party libraries to use AndroidX
 - android.enableJetifier=true
+```
+
+### Update to Java 17
+
+```diff
+# build.gradle
+compileOptions {
+-    sourceCompatibility JavaVersion.VERSION_11
++    sourceCompatibility JavaVersion.VERSION_17
+-    targetCompatibility JavaVersion.VERSION_11
++    targetCompatibility JavaVersion.VERSION_17
+}
 ```


### PR DESCRIPTION
Separated the migration steps from the breaking changes in code

Added information about `@capacitor/plugin-migration-v4-to-v5`

Added missing updates such as npm package updates and java 17