### PR TITLE
Reorgnize plugin migration guide

### DIFF
--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -33,10 +33,11 @@ From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5@latest` an
 
 Update `@capacitor/cli`, `@capacitor/core`, `@capacitor/android` and `@capacitor/ios` to `next` version.
 
-### Updating targetSDK / compileSDK to 33
-```diff
-# build.gradle
+### Updating build.gradle
 
+Update the targetSDK / compileSDK to 33:
+
+```diff
 android {
 -    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
 +    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
@@ -44,9 +45,7 @@ android {
 +    targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
 ```
 
-### Update Android Plugin Variables
-
-In your `build.gradle` file, update the following package version minimums:
+Update the Android Plugin minimum version variables:
 
 ```diff
 ext {
@@ -59,7 +58,7 @@ ext {
 +   androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
 ```
 
-### Update gradle plugin to 8.0.0
+Update the gradle plugin to 8.0.0:
 
 ```diff
     dependencies {
@@ -68,54 +67,9 @@ ext {
     }
 ```
 
-### Update gradle wrapper to 8.0.2
+Update to Java 17:
 
 ```diff
-# gradle-wrapper.properties
-
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-- distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
-+ distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-```
-
-### Move package to `build.gradle`
-
-```diff
-# AndroidManifest.xml
-
-<?xml version="1.0" encoding="utf-8"?>
-- <manifest xmlns:android="http://schemas.android.com/apk/res/android"
--     package="[YOUR_PACKAGE_ID]">
-+ <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-```
-
-```diff
-# build.gradle
-
-android {
-+     namespace "[YOUR_PACKAGE_ID]"
-      compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
-```
-
-### Disable Jetifier
-
-```diff 
-# gradle.properties
-
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-- # Automatically convert third-party libraries to use AndroidX
-- android.enableJetifier=true
-```
-
-### Update to Java 17
-
-```diff
-# build.gradle
 compileOptions {
 -    sourceCompatibility JavaVersion.VERSION_11
 +    sourceCompatibility JavaVersion.VERSION_17
@@ -124,12 +78,9 @@ compileOptions {
 }
 ```
 
-### Update kotlin_version
-
-If your plugin uses kotlin, update the default `kotlin_version`
+Update `kotlin_version` **if your plugin uses kotlin**:
 
 ```diff
-# build.gradle
 buildscript {
 -    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.7.0'
 +    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.8.20'
@@ -140,8 +91,51 @@ And replace `org.jetbrains.kotlin:kotlin-stdlib-jdk7` or `org.jetbrains.kotlin:k
 
 
 ```diff
-# build.gradle
 dependencies {
 -    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 +    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+```
+
+### Updating gradle-wrapper.properties:
+
+Update gradle wrapper to 8.0.2:
+
+```diff
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+- distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
++ distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+```
+
+### Updating gradle.properties
+
+Disable Jetifier:
+
+```diff 
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+- # Automatically convert third-party libraries to use AndroidX
+- android.enableJetifier=true
+```
+
+### Moving the package to `build.gradle`
+
+In **AndroidManifest.xml**:
+
+```diff
+<?xml version="1.0" encoding="utf-8"?>
+- <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+-     package="[YOUR_PACKAGE_ID]">
++ <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+```
+
+In **build.gradle**:
+
+```diff
+android {
++     namespace "[YOUR_PACKAGE_ID]"
+      compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
 ```


### PR DESCRIPTION
I revised the order of modifications to be per file; previously, the changes were scattered regardless of what file they needed to be made in.  Some places had the filename in the diff, while others had it in the leading text.  To make it consistent, I made a header for each file.