### PR TITLE
docs: add missing Capacitor 5 plugin info

### DIFF
--- a/docs/main/updating/5-0.md
+++ b/docs/main/updating/5-0.md
@@ -177,18 +177,47 @@ If your project is using kotlin, update the `kotlin_version` variable to `'1.8.2
 
 The following plugin functionality has been modified or removed. Update your code accordingly.
 
+### Action Sheet
+
+- `androidxMaterialVersion` variable has been updated to `1.8.0`.
+
+### Browser
+
+- `androidxBrowserVersion` variable has been updated to `1.5.0`.
+
+### Camera
+
+- Android 13 requiries to declare read media images permission (`<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>`) in `AndroidManifest.xml`.
+- `androidxMaterialVersion` variable has been updated to `1.8.0`.
+- `androidxExifInterfaceVersion` variable has been updated to `1.3.6`.
+
 ### Device
 
 - `DeviceId.uuid` changed to `DeviceId.identifier`
 - On iOS 16+, `DeviceInfo.name` will return a generic device name unless you add the appropriate [entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name).
 
-### Push Notifications
+### Geolocation
 
-- Android 13 requires a new runtime permission check in order to receive push notifications. You are required to call `checkPermissions()` and `requestPermissions()` accordingly, when targeting SDK 33.
+- `playServicesLocationVersion` has been updated to `21.0.1`.
+
+### Google Maps
+
+- `googleMapsPlayServicesVersion` has been updated to `18.1.0`.
+- `googleMapsUtilsVersion` has been updated to `3.4.0`.
+- `googleMapsKtxVersion` has been updated to `3.4.0`.
+- `googleMapsUtilsKtxVersion` has been updated to `3.4.0`.
+- `kotlinxCoroutinesVersion` has been updated to `1.6.4`.
+- `androidxCoreKTXVersion` has been updated to `1.10.0`.
+- `kotlin_version` has been updated to `1.8.20`.
 
 ### Local Notifications
 
 - Android 13 requires a new runtime permission check in order to schedule local notifications. You are required to call `checkPermissions()` and `requestPermissions()` accordingly, when targeting SDK 33.
+
+### Push Notifications
+
+- Android 13 requires a new runtime permission check in order to receive push notifications. You are required to call `checkPermissions()` and `requestPermissions()` accordingly, when targeting SDK 33.
+- `firebaseMessagingVersion` variable has been updated to `23.1.2`.
 
 ### Status Bar
 


### PR DESCRIPTION
The guide was missing the new required camera permission `<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>`

Also we didn't document the default values of the plugin variables, so I've added them (v4 guide included that information)