### PR TITLE
Update http.md to reflect code in CapacitorHttpUrlConnection

### DIFF
--- a/docs/apis/http.md
+++ b/docs/apis/http.md
@@ -67,11 +67,15 @@ const doGet = () => {
 };
 
 // Example of a POST request. Note: data
-// can be passed as a raw JS Object (must be JSON serializable)
+// can be passed as a raw JS Object (must be JSON serializable).
+// Content-Type is required for body to be sent with POST/PUT/PATCH requests.
 const doPost = () => {
   const options = {
     url: 'https://example.com/my/api',
-    headers: { 'X-Fake-Header': 'Fake-Value' },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Fake-Header': 'Fake-Value',
+    },
     data: { foo: 'bar' },
   };
 


### PR DESCRIPTION
Was having trouble getting my post requests to send a JSON body, even though my code matched the documentation's demo.

Found out by looking at the @capacitor/core Java code that if ContentType isn't set, it'll just `return` and not set the body of the request.

https://github.com/ionic-team/capacitor/blob/895f86a81ee76b23ed33fa088ee3c9feec1ecd7f/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java#LL180C46-L180C46

Let me know if you'd prefer to handle something like this a little different. I would've preferred `CapacitorHttpUrlConnection.setRequestBody()` to throw an Exception, but I figured I'd just try to document the gotcha.