### PR TITLE
docs: Get capacitor 5 final plugin docs

### DIFF
--- a/docs/apis/action-sheet.md
+++ b/docs/apis/action-sheet.md
@@ -21,7 +21,7 @@ npx cap sync
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.8.0`)
+- `androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.8.0`)
 
 ## PWA Notes
 

--- a/docs/apis/browser.md
+++ b/docs/apis/browser.md
@@ -25,7 +25,7 @@ npx cap sync
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$androidxBrowserVersion`: version of `androidx.browser:browser` (default: `1.5.0`)
+- `androidxBrowserVersion`: version of `androidx.browser:browser` (default: `1.5.0`)
 
 ## Example
 

--- a/docs/apis/camera.md
+++ b/docs/apis/camera.md
@@ -47,8 +47,8 @@ Additionally, because the Camera API launches a separate Activity to handle taki
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$androidxExifInterfaceVersion`: version of `androidx.exifinterface:exifinterface` (default: `1.3.6`)
-- `$androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.8.0`)
+- `androidxExifInterfaceVersion`: version of `androidx.exifinterface:exifinterface` (default: `1.3.6`)
+- `androidxMaterialVersion`: version of `com.google.android.material:material` (default: `1.8.0`)
 
 ## PWA Notes
 
@@ -207,22 +207,22 @@ Request camera and photo album permissions
 
 #### Photo
 
-| Prop               | Type                 | Description                                                                                                                                                                                                      | Since |
-| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| **`base64String`** | <code>string</code>  | The base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.Base64</a>.                                                                                         | 1.0.0 |
-| **`dataUrl`**      | <code>string</code>  | The url starting with 'data:image/jpeg;base64,' and the base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.DataUrl</a>.                                    | 1.0.0 |
-| **`path`**         | <code>string</code>  | If using <a href="#cameraresulttype">CameraResultType.Uri</a>, the path will contain a full, platform-specific file URL that can be read later using the Filesystem API.                                         | 1.0.0 |
-| **`webPath`**      | <code>string</code>  | webPath returns a path that can be used to set the src attribute of an image for efficient loading and rendering.                                                                                                | 1.0.0 |
-| **`exif`**         | <code>any</code>     | Exif data, if any, retrieved from the image                                                                                                                                                                      | 1.0.0 |
-| **`format`**       | <code>string</code>  | The format of the image, ex: jpeg, png, gif. iOS and Android only support jpeg. Web supports jpeg and png. gif is only supported if using file input.                                                            | 1.0.0 |
-| **`saved`**        | <code>boolean</code> | Whether if the image was saved to the gallery or not. On Android and iOS, saving to the gallery can fail if the user didn't grant the required permissions. On Web there is no gallery, so always returns false. | 1.1.0 |
+| Prop               | Type                 | Description                                                                                                                                                                                                                                                              | Since |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`base64String`** | <code>string</code>  | The base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.Base64</a>.                                                                                                                                                 | 1.0.0 |
+| **`dataUrl`**      | <code>string</code>  | The url starting with 'data:image/jpeg;base64,' and the base64 encoded string representation of the image, if using <a href="#cameraresulttype">CameraResultType.DataUrl</a>. Note: On web, the file format could change depending on the browser.                       | 1.0.0 |
+| **`path`**         | <code>string</code>  | If using <a href="#cameraresulttype">CameraResultType.Uri</a>, the path will contain a full, platform-specific file URL that can be read later using the Filesystem API.                                                                                                 | 1.0.0 |
+| **`webPath`**      | <code>string</code>  | webPath returns a path that can be used to set the src attribute of an image for efficient loading and rendering.                                                                                                                                                        | 1.0.0 |
+| **`exif`**         | <code>any</code>     | Exif data, if any, retrieved from the image                                                                                                                                                                                                                              | 1.0.0 |
+| **`format`**       | <code>string</code>  | The format of the image, ex: jpeg, png, gif. iOS and Android only support jpeg. Web supports jpeg, png and gif, but the exact availability may vary depending on the browser. gif is only supported if `webUseInput` is set to `true` or if `source` is set to `Photos`. | 1.0.0 |
+| **`saved`**        | <code>boolean</code> | Whether if the image was saved to the gallery or not. On Android and iOS, saving to the gallery can fail if the user didn't grant the required permissions. On Web there is no gallery, so always returns false.                                                         | 1.1.0 |
 
 
 #### ImageOptions
 
 | Prop                     | Type                                                          | Description                                                                                                                                                                                                                                                                | Default                             | Since |
 | ------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----- |
-| **`quality`**            | <code>number</code>                                           | The quality of image to return as JPEG, from 0-100                                                                                                                                                                                                                         |                                     | 1.0.0 |
+| **`quality`**            | <code>number</code>                                           | The quality of image to return as JPEG, from 0-100 Note: This option is only supported on Android and iOS                                                                                                                                                                  |                                     | 1.0.0 |
 | **`allowEditing`**       | <code>boolean</code>                                          | Whether to allow the user to crop or make small edits (platform specific). On iOS 14+ it's only supported for <a href="#camerasource">CameraSource.Camera</a>, but not for <a href="#camerasource">CameraSource.Photos</a>.                                                |                                     | 1.0.0 |
 | **`resultType`**         | <code><a href="#cameraresulttype">CameraResultType</a></code> | How the data should be returned. Currently, only 'Base64', 'DataUrl' or 'Uri' is supported                                                                                                                                                                                 |                                     | 1.0.0 |
 | **`saveToGallery`**      | <code>boolean</code>                                          | Whether to save the photo to the gallery. If the photo was picked from the gallery, it will only be saved if edited.                                                                                                                                                       | <code>: false</code>                | 1.0.0 |
@@ -258,14 +258,14 @@ Request camera and photo album permissions
 
 #### GalleryImageOptions
 
-| Prop                     | Type                                   | Description                                                                                | Default                     | Since |
-| ------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | ----- |
-| **`quality`**            | <code>number</code>                    | The quality of image to return as JPEG, from 0-100                                         |                             | 1.2.0 |
-| **`width`**              | <code>number</code>                    | The desired maximum width of the saved image. The aspect ratio is respected.               |                             | 1.2.0 |
-| **`height`**             | <code>number</code>                    | The desired maximum height of the saved image. The aspect ratio is respected.              |                             | 1.2.0 |
-| **`correctOrientation`** | <code>boolean</code>                   | Whether to automatically rotate the image "up" to correct for orientation in portrait mode | <code>: true</code>         | 1.2.0 |
-| **`presentationStyle`**  | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the Camera.                                            | <code>: 'fullscreen'</code> | 1.2.0 |
-| **`limit`**              | <code>number</code>                    | iOS only: Maximum number of pictures the user will be able to choose.                      | <code>0 (unlimited)</code>  | 1.2.0 |
+| Prop                     | Type                                   | Description                                                                                                | Default                     | Since |
+| ------------------------ | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------- | ----- |
+| **`quality`**            | <code>number</code>                    | The quality of image to return as JPEG, from 0-100 Note: This option is only supported on Android and iOS. |                             | 1.2.0 |
+| **`width`**              | <code>number</code>                    | The desired maximum width of the saved image. The aspect ratio is respected.                               |                             | 1.2.0 |
+| **`height`**             | <code>number</code>                    | The desired maximum height of the saved image. The aspect ratio is respected.                              |                             | 1.2.0 |
+| **`correctOrientation`** | <code>boolean</code>                   | Whether to automatically rotate the image "up" to correct for orientation in portrait mode                 | <code>: true</code>         | 1.2.0 |
+| **`presentationStyle`**  | <code>'fullscreen' \| 'popover'</code> | iOS only: The presentation style of the Camera.                                                            | <code>: 'fullscreen'</code> | 1.2.0 |
+| **`limit`**              | <code>number</code>                    | iOS only: Maximum number of pictures the user will be able to choose.                                      | <code>0 (unlimited)</code>  | 1.2.0 |
 
 
 #### PermissionStatus

--- a/docs/apis/geolocation.md
+++ b/docs/apis/geolocation.md
@@ -45,7 +45,7 @@ Read about [Setting Permissions](https://capacitorjs.com/docs/android/configurat
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$playServicesLocationVersion` version of `com.google.android.gms:play-services-location` (default: `21.0.1`)
+- `playServicesLocationVersion` version of `com.google.android.gms:play-services-location` (default: `21.0.1`)
 
 ## Example
 

--- a/docs/apis/google-maps.md
+++ b/docs/apis/google-maps.md
@@ -30,7 +30,7 @@ The Google Maps SDK supports the use of showing the users current location via `
 
 Read about [Configuring `Info.plist`](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) in the [iOS Guide](https://capacitorjs.com/docs/ios) for more information on setting iOS permissions in Xcode.
 
-> The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, however, a dependency from Google called [Google-Maps-Utils-iOS](https://github.com/googlemaps/google-maps-ios-utils) does not yet support Apple Silicon. This is requires a new release of the library from Google. If you are developing on an Apple Silicon Mac, building and running on physical devices is still supported and is the recommended approach.
+> The main Google Maps SDK now supports running on simulators on Apple Silicon Macs, however, a dependency from Google called [Google-Maps-iOS-Utils](https://github.com/googlemaps/google-maps-ios-utils) does not yet support Apple Silicon. This is requires a new release of the library from Google. If you are developing on an Apple Silicon Mac, building and running on physical devices is still supported and is the recommended approach.
 
 > A workaround on Apple Silicon Macs if you want/need to use the simulator is adding the following line to your Podfile in the `target 'App'` section after the `# Add your Pods here` line:
 
@@ -57,13 +57,13 @@ To use certain location features, the SDK requires the following permissions to 
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$googleMapsPlayServicesVersion`: version of `com.google.android.gms:play-services-maps` (default: `18.1.0`)
-- `$googleMapsUtilsVersion`: version of `com.google.maps.android:android-maps-utils` (default: `3.4.0`)
-- `$googleMapsKtxVersion`: version of `com.google.maps.android:maps-ktx` (default: `3.4.0`)
-- `$googleMapsUtilsKtxVersion`: version of `com.google.maps.android:maps-utils-ktx` (default: `3.4.0`)
-- `$kotlinxCoroutinesVersion`: version of `org.jetbrains.kotlinx:kotlinx-coroutines-android` and `org.jetbrains.kotlinx:kotlinx-coroutines-core` (default: `1.6.4`)
-- `$androidxCoreKTXVersion`: version of `androidx.core:core-ktx` (default: `1.10.0`)
-- `$kotlin_version`: version of `org.jetbrains.kotlin:kotlin-stdlib-jdk7` (default: `1.8.20`)
+- `googleMapsPlayServicesVersion`: version of `com.google.android.gms:play-services-maps` (default: `18.1.0`)
+- `googleMapsUtilsVersion`: version of `com.google.maps.android:android-maps-utils` (default: `3.4.0`)
+- `googleMapsKtxVersion`: version of `com.google.maps.android:maps-ktx` (default: `3.4.0`)
+- `googleMapsUtilsKtxVersion`: version of `com.google.maps.android:maps-utils-ktx` (default: `3.4.0`)
+- `kotlinxCoroutinesVersion`: version of `org.jetbrains.kotlinx:kotlinx-coroutines-android` and `org.jetbrains.kotlinx:kotlinx-coroutines-core` (default: `1.6.4`)
+- `androidxCoreKTXVersion`: version of `androidx.core:core-ktx` (default: `1.10.0`)
+- `kotlin_version`: version of `org.jetbrains.kotlin:kotlin-stdlib-jdk7` (default: `1.8.20`)
 
 
 ## Usage

--- a/docs/apis/push-notifications.md
+++ b/docs/apis/push-notifications.md
@@ -43,7 +43,7 @@ Android 13 requires a permission check in order to receive push notifications.  
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-- `$firebaseMessagingVersion` version of `com.google.firebase:firebase-messaging` (default: `23.1.2`)
+- `firebaseMessagingVersion` version of `com.google.firebase:firebase-messaging` (default: `23.1.2`)
 
 ---
 

--- a/docs/apis/splash-screen.md
+++ b/docs/apis/splash-screen.md
@@ -189,11 +189,11 @@ To use splash screen images named something other than `splash.png`, set `androi
 </style>
 ```
 
-## Variables
+### Variables
 
 This plugin will use the following project variables (defined in your app's `variables.gradle` file):
 
-`$coreSplashScreenVersion` version of `androidx.core:core-splashscreen:$coreSplashScreenVersion` (default: `1.0.0`)
+- `coreSplashScreenVersion` version of `androidx.core:core-splashscreen` (default: `1.0.0`)
 
 ## Example Guides
 

--- a/scripts/api-v4.mjs
+++ b/scripts/api-v4.mjs
@@ -4,8 +4,7 @@ import fetch from 'node-fetch';
 
 const API_DIR = new URL('../versioned_docs/version-v4/apis/', import.meta.url);
 
-// replace with latest once it's relased
-const tag = 'latest';
+const tag = 'latest-4';
 
 const pluginApis = [
   'action-sheet',

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -4,8 +4,7 @@ import fetch from 'node-fetch';
 
 const API_DIR = new URL('../docs/apis/', import.meta.url);
 
-// replace with latest once it's relased
-const tag = 'next';
+const tag = 'latest';
 
 const pluginApis = [
   'action-sheet',


### PR DESCRIPTION
update plugin generators to use latest tag on capacitor 5 and latest-4 tag on capacitor 4 (note, we need to mark all Capacitor 4 packages as latest-4)
