### PR TITLE
chore: redirect next to root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,7 @@
   ],
   "redirects": [
     { "source": "/", "destination": "/docs" },
+    { "source": "/docs/next/:match*", "destination": "/docs/:match*" },
     { "source": "/docs/apis/storage", "destination": "/docs/apis/preferences" }
   ],
   "rewrites": [


### PR DESCRIPTION
@jaredcbaum not sure if this should go here or in capacitor-site repository, but we need to redirect the now non existent "docs/next/whatever" urls to "docs/whatever".

This change seems to work