### PR TITLE
fix(config): Add java and kotlin to Prism languages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,7 +177,7 @@ module.exports = {
     prism: {
       theme: { plain: {}, styles: [] },
       // https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js
-      additionalLanguages: ['shell-session', 'http', 'swift'],
+      additionalLanguages: ['shell-session', 'http', 'swift', 'java', 'kotlin'],
     },
     algolia: {
       appId: '3IVALO5OU4',


### PR DESCRIPTION
This adds syntax highlighting to pages like this:
https://capacitorjs.com/docs/v2/plugins/android
https://capacitorjs.com/docs/plugins/android