### PR TITLE
add `--flavor` option to `npx cap build` cmd

### DIFF
--- a/docs/cli/commands/build.md
+++ b/docs/cli/commands/build.md
@@ -18,10 +18,10 @@ npx cap build [options] <platform>
 
 <strong>Options:</strong>
 
-- `--scheme <scheme-to-build>` - iOS Scheme to build (default is App)
-- `--flavor <flavor-to-build>` - Android Flavor to build
+- `--scheme <scheme-to-build>`: iOS Scheme to build (default is App)
+- `--flavor <flavor-to-build>`: Android Flavor to build
 - `--keystorepath <path>`: Path to the keystore file
 - `--keystorepass <keystore-password>`: Password to the keystore
-- `--keystorealias <alias>` - Key alias in the keystore
-- `--keystorealiaspass <alias-password>` - Password for the keystore alias
-- `--androidreleasetype <release-type>` - Can be either `AAB` or `APK`
+- `--keystorealias <alias>`: Key alias in the keystore
+- `--keystorealiaspass <alias-password>`: Password for the keystore alias
+- `--androidreleasetype <release-type>`: Can be either `AAB` or `APK`

--- a/docs/cli/commands/build.md
+++ b/docs/cli/commands/build.md
@@ -18,9 +18,10 @@ npx cap build [options] <platform>
 
 <strong>Options:</strong>
 
+- `--scheme <scheme-to-build>` - iOS Scheme to build (default is App)
+- `--flavor <flavor-to-build>` - Android Flavor to build
 - `--keystorepath <path>`: Path to the keystore file
 - `--keystorepass <keystore-password>`: Password to the keystore
 - `--keystorealias <alias>` - Key alias in the keystore
 - `--keystorealiaspass <alias-password>` - Password for the keystore alias
 - `--androidreleasetype <release-type>` - Can be either `AAB` or `APK`
-- `--scheme <scheme-to-build>` - iOS Scheme to build (default is App)

--- a/docs/cli/commands/build.md
+++ b/docs/cli/commands/build.md
@@ -18,7 +18,7 @@ npx cap build [options] <platform>
 
 <strong>Options:</strong>
 
-- `--scheme <scheme-to-build>`: iOS Scheme to build (default is App)
+- `--scheme <scheme-to-build>`: iOS Scheme to build (default is `App`)
 - `--flavor <flavor-to-build>`: Android Flavor to build
 - `--keystorepath <path>`: Path to the keystore file
 - `--keystorepass <keystore-password>`: Password to the keystore


### PR DESCRIPTION
The `--flavor` option is missing in the docs