### PR TITLE
chore: replace no-break space with normal whitespace

### DIFF
--- a/docs/main/updating/4-0.md
+++ b/docs/main/updating/4-0.md
@@ -20,7 +20,7 @@ The following guide describes how to upgrade your Capacitor 3 iOS project to Cap
 
 Do the following for your Xcode project: select the **Project** within the project editor and open the **Build Settings** tab. Under the **Deployment** section, change **iOS Deployment Target** to **iOS 13.0**. Repeat the same steps for any app **Targets**.
 
-Then, open `ios/App/Podfile` and follow these steps:
+Then, open `ios/App/Podfile` and follow these steps:
 1. Add this on the first line:
 
 ```ruby

--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -124,7 +124,7 @@ compileOptions {
 }
 ```
 
-### Update kotlin_version
+### Update kotlin_version
 
 If your plugin uses kotlin, update the default `kotlin_version`
 

--- a/versioned_docs/version-v4/main/updating/4-0.md
+++ b/versioned_docs/version-v4/main/updating/4-0.md
@@ -20,7 +20,7 @@ The following guide describes how to upgrade your Capacitor 3 iOS project to Cap
 
 Do the following for your Xcode project: select the **Project** within the project editor and open the **Build Settings** tab. Under the **Deployment** section, change **iOS Deployment Target** to **iOS 13.0**. Repeat the same steps for any app **Targets**.
 
-Then, open `ios/App/Podfile` and follow these steps:
+Then, open `ios/App/Podfile` and follow these steps:
 1. Add this on the first line:
 
 ```ruby


### PR DESCRIPTION
Close #188

This PR replace the no-break space (U+00A0) with normal whitespace (U+0020).

This change will ensure that the markdown parser can parse the text properly, and thus avoids some unexpected results.