### PR TITLE
Fix order in sidebar for the Plugin Tutorial

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -27,7 +27,7 @@ module.exports = {
         'main/getting-started/faqs',
       ],
     },
-    
+
     {
       type: 'category',
       label: 'Basics',
@@ -186,8 +186,8 @@ module.exports = {
         'plugins/tutorial/getting-started',
         'plugins/tutorial/designing-api',
         'plugins/tutorial/using-api',
-        'plugins/tutorial/code-abstraction',
         'plugins/tutorial/implementing-for-web',
+        'plugins/tutorial/code-abstraction',
         'plugins/tutorial/implementing-for-ios',
         'plugins/tutorial/implementing-for-android',
         'plugins/tutorial/packaging',

--- a/versioned_sidebars/version-v3-sidebars.json
+++ b/versioned_sidebars/version-v3-sidebars.json
@@ -195,8 +195,8 @@
         "version-v3/plugins/tutorial/getting-started",
         "version-v3/plugins/tutorial/designing-api",
         "version-v3/plugins/tutorial/using-api",
-        "version-v3/plugins/tutorial/code-abstraction",
         "version-v3/plugins/tutorial/implementing-for-web",
+        "version-v3/plugins/tutorial/code-abstraction",
         "version-v3/plugins/tutorial/implementing-for-ios",
         "version-v3/plugins/tutorial/implementing-for-android",
         "version-v3/plugins/tutorial/packaging"

--- a/versioned_sidebars/version-v4-sidebars.json
+++ b/versioned_sidebars/version-v4-sidebars.json
@@ -423,11 +423,11 @@
         },
         {
           "type": "doc",
-          "id": "version-v4/plugins/tutorial/code-abstraction"
+          "id": "version-v4/plugins/tutorial/implementing-for-web"
         },
         {
           "type": "doc",
-          "id": "version-v4/plugins/tutorial/implementing-for-web"
+          "id": "version-v4/plugins/tutorial/code-abstraction"
         },
         {
           "type": "doc",


### PR DESCRIPTION
**Problem:**
In the the Plugin Tutorial:
After *Using the Plugin API* the text ends with *[...] next step: the web implementation.*

After *Implementing for Web/PWA* the text ends with *[...]  the next step: code abstraction patterns.*

**Solution:**
Fix order in sidebar for the Plugin Tutorial for versions:
- V3, V4, V5
V2 does not have the tutorial.