### PR TITLE
Add Background Runner and Watch plugins to "Official plugins" list

### DIFF
--- a/docs/plugins/official.md
+++ b/docs/plugins/official.md
@@ -20,6 +20,7 @@ The API documentation for these plugins can be found below.
 - [Action Sheet](/docs/apis/action-sheet)
 - [App](/docs/apis/app)
 - [App Launcher](/docs/apis/app-launcher)
+- [Background Runner](/docs/apis/background-runner)
 - [Browser](/docs/apis/browser)
 - [Camera](/docs/apis/camera)
 - [Clipboard](/docs/apis/clipboard)
@@ -43,6 +44,7 @@ The API documentation for these plugins can be found below.
 - [Status Bar](/docs/apis/status-bar)
 - [Text Zoom](/docs/apis/text-zoom)
 - [Toast](/docs/apis/toast)
+- [Watch 🧪](/docs/apis/watch)
 
 ## GitHub
 


### PR DESCRIPTION
Add the Background Runner and Watch plugins to the [Official plugins](https://capacitorjs.com/docs/apis) list.