### PR TITLE
Update cookies.md to explain WKAppBoundDomains restrictions

### DIFF
--- a/docs/apis/cookies.md
+++ b/docs/apis/cookies.md
@@ -99,14 +99,7 @@ As of iOS 14, you cannot use 3rd party cookies by default. Add the following lin
 </array>
 ```
 
-Adding the ```WKAppBoundDomains``` key to ```Info.plist``` causes all WKWebView instances in the application to be restricted however. Access to the following APIs will be denied:
-
-- JavaScript injection
-- custom style sheets
-- cookie manipulation
-- message handlers
-
-To re-enable these APIs, set the "ios.limitsNavigationsToAppBoundDomains" in your ```capacitor.config.ts``` to ```true```.
+When using ```WKAppBoundDomains``` you must also set ```ios.limitsNavigationsToAppBoundDomains``` to ```true``` in your ```capacitor.config.ts``` to avoid any issues with plugins and WKWebView APIs.
 
 ## API
 

--- a/docs/apis/cookies.md
+++ b/docs/apis/cookies.md
@@ -99,6 +99,15 @@ As of iOS 14, you cannot use 3rd party cookies by default. Add the following lin
 </array>
 ```
 
+Adding the ```WKAppBoundDomains``` key to ```Info.plist``` causes all WKWebView instances in the application to be restricted however. Access to the following APIs will be denied:
+
+- JavaScript injection
+- custom style sheets
+- cookie manipulation
+- message handlers
+
+To re-enable these APIs, set the "ios.limitsNavigationsToAppBoundDomains" in your ```capacitor.config.ts``` to ```true```.
+
 ## API
 
 <docgen-index>


### PR DESCRIPTION
Webkit docs at https://webkit.org/blog/10882/app-bound-domains/ explain this:

"Once the WKAppBoundDomains key is added to the Info.plist, all WKWebView instances in the application default to a mode where JavaScript injection, custom style sheets, cookie manipulation, and message handler use is denied. To gain back access to these APIs, a WKWebView can set the limitsNavigationsToAppBoundDomains flag in their WKWebView configuration, like so:

webViewConfiguration.limitsNavigationsToAppBoundDomains = YES;"

Please rephrase as you see fit.