### PR TITLE
Fix broken links to CLI Hooks documentation

### DIFF
--- a/docs/cli/commands/copy.md
+++ b/docs/cli/commands/copy.md
@@ -29,4 +29,4 @@ The following hooks are available for copy command:
 - `capacitor:copy:before`
 - `capacitor:copy:after`
 
-[More information](hooks)
+[More information](../hooks)

--- a/docs/cli/commands/sync.md
+++ b/docs/cli/commands/sync.md
@@ -30,4 +30,4 @@ The following hooks are available for sync command:
 - `capacitor:sync:before`
 - `capacitor:sync:after`
 
-[More information](hooks)
+[More information](../hooks)

--- a/docs/cli/commands/update.md
+++ b/docs/cli/commands/update.md
@@ -29,4 +29,4 @@ The following hooks are available for update command:
 - `capacitor:update:before`
 - `capacitor:update:after`
 
-[More information](hooks)
+[More information](../hooks)


### PR DESCRIPTION
Currently the links to the CLI Hooks documentation are broken.
I fixed the links to get them reaching the docs one level up. 