### PR TITLE
docs: update config for androidScheme

### DIFF
--- a/docs/main/reference/config.md
+++ b/docs/main/reference/config.md
@@ -501,6 +501,11 @@ export interface CapacitorConfig {
     /**
      * Configure the local scheme on Android.
      *
+     * Custom schemes on Android are unable to change the URL path as of Webview 117. Changing this value from anything other than `http` or `https` can result in your
+     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarentees that this
+     * will continue to work long term as allowing non-standard schemes to modify query parameters and url fragments is only allowed for compatibility reasons.
+     * https://chromium-review.googlesource.com/c/chromium/src/+/4701743
+     *
      * @since 1.2.0
      * @default http
      */

--- a/docs/main/reference/config.md
+++ b/docs/main/reference/config.md
@@ -504,7 +504,7 @@ export interface CapacitorConfig {
      * Custom schemes on Android are unable to change the URL path as of Webview 117. Changing this value from anything other than `http` or `https` can result in your
      * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarentees that this
      * will continue to work long term as allowing non-standard schemes to modify query parameters and url fragments is only allowed for compatibility reasons.
-     * https://chromium-review.googlesource.com/c/chromium/src/+/4701743
+     * https://ionic.io/blog/capacitor-android-customscheme-issue-with-chrome-117
      *
      * @since 1.2.0
      * @default http


### PR DESCRIPTION
updates the config definition for androidScheme to include information about the change in Android Webview 117