### PR TITLE
docs(pwa-elements): Change information around defineCustomElements call

### DIFF
--- a/docs/main/web/pwa-elements.md
+++ b/docs/main/web/pwa-elements.md
@@ -13,7 +13,7 @@ Some Capacitor plugins, such as `Camera` or `Toast`, have web-based UI available
 
 <img src={require('/img/v5/docs/pwa-elements.png').default} style={{height: "200px"}} />
 
-This UI is implemented using web components. Due to the magic of Shadow DOM, these components should not conflict
+This UI is implemented using web components. Due the elements being encapsulated by the [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), these components should not conflict
 with your own UI.
 
 ## Installation
@@ -30,42 +30,38 @@ npm install @ionic/pwa-elements
 
 Then, depending on your framework of choice, import the element loader and call it at the correct time:
 
-_React_
+##### React
 
-`index.tsx` or `index.js`:
+`main.tsx` or `index.tsx` or `index.js`:
 
 ```tsx
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
 
-ReactDOM.render(<App />, document.getElementById('root'));
-
-// Call the element loader after the app has been rendered the first time
+// Call the element loader before the render call
 defineCustomElements(window);
 ```
 
-_Angular_
+##### Vue
 
 `main.ts`:
 
 ```typescript
-import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
-import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
-
+// Above the createApp() line
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
+defineCustomElements(window);
+```
 
+##### Angular
+
+`main.ts`:
+
+```typescript
+import { defineCustomElements } from '@ionic/pwa-elements/loader';
+// Call the element loader before the bootstrapModule/bootstrapApplication call
+defineCustomElements(window);
 if (environment.production) {
   enableProdMode();
 }
-
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .catch(err => console.log(err));
-
-// Call the element loader after the platform has been bootstrapped
-defineCustomElements(window);
 ```
 
 #### Including through script tag


### PR DESCRIPTION
When the docs were migrated some changes made [here](https://github.com/ionic-team/capacitor-site/pull/285) were missed (titles, shadow dom link, vue example, etc.), so bringing them back.
Also changed the docs around the defineCustomElements since it should be called before the app is rendered/registered/created.