### PR TITLE
docs(isNative): Update utilities.md

### DIFF
--- a/versioned_docs/version-v2/basics/utilities.md
+++ b/versioned_docs/version-v2/basics/utilities.md
@@ -51,14 +51,14 @@ if (Capacitor.getPlatform() === 'ios') {
 }
 ```
 
-## isNative
+## isNativePlatform
 
-`isNative?: boolean;`
+`isNativePlatformm: () => boolean;`
 
 Check whether the currently running platform is native (`ios`, `android`).
 
 ```typescript
-if (Capacitor.isNative) {
+if (Capacitor.isNativePlatform()) {
   // do something
 }
 ```


### PR DESCRIPTION
Match code to docs.
--
`Capacitor.isNative` is deprecated.
Use `isNativePlatform()` instead.

![CleanShot 2023-10-27 at 11 32 44](https://github.com/ionic-team/capacitor-docs/assets/5682899/695ce001-7fed-42e8-91e3-bdba3fc8b715)
