### PR TITLE
Update splash-screens-and-icons.md to right path

### DIFF
--- a/docs/main/guides/splash-screens-and-icons.md
+++ b/docs/main/guides/splash-screens-and-icons.md
@@ -16,7 +16,7 @@ npm install @capacitor/assets --save-dev
 
 Provide icon and splash screen source images using this folder/filename structure:
 ```
-resources/
+assets/
 ├── icon-only.png
 ├── icon-foreground.png
 ├── icon-background.png


### PR DESCRIPTION
The @capacitor/assets lib recommends to use /assets instead /resources folder.