### PR TITLE
Revert next directory redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,6 @@
   ],
   "redirects": [
     { "source": "/", "destination": "/docs" },
-    { "source": "/docs/next/:match*", "destination": "/docs/:match*" },
     { "source": "/docs/apis/storage", "destination": "/docs/apis/preferences" }
   ],
   "rewrites": [


### PR DESCRIPTION
This reverts commit 9bbc99cdee20e18bb602f299eff309ef70ef291b.

v6 is now being shown under "next" so we need to revert this change. Next time the redirects should be marked as temporary.