### PR TITLE
chore: Update Capacitor 5 config file docs

### DIFF
--- a/versioned_docs/version-v5/main/reference/config.md
+++ b/versioned_docs/version-v5/main/reference/config.md
@@ -293,6 +293,14 @@ export interface CapacitorConfig {
        * @default "AAB"
        */
       releaseType?: 'AAB' | 'APK';
+
+      /**
+       * Program to sign your build with
+       *
+       * @since 5.1.0
+       * @default "jarsigner"
+       */
+      signingType?: 'apksigner' | 'jarsigner';
     };
 
     /**
@@ -501,6 +509,11 @@ export interface CapacitorConfig {
     /**
      * Configure the local scheme on Android.
      *
+     * Custom schemes on Android are unable to change the URL path as of Webview 117. Changing this value from anything other than `http` or `https` can result in your
+     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarentees that this
+     * will continue to work long term as allowing non-standard schemes to modify query parameters and url fragments is only allowed for compatibility reasons.
+     * https://ionic.io/blog/capacitor-android-customscheme-issue-with-chrome-117
+     *
      * @since 1.2.0
      * @default http
      */
@@ -662,6 +675,14 @@ export interface PluginsConfig {
      * @default false
      */
     enabled?: boolean;
+    /**
+     * Enable `httpOnly` and other insecure cookies to be read and accessed on Android.
+     *
+     * Note: This can potentially be a security risk and is only intended to be used
+     * when your application uses a custom scheme on Android.
+     *
+     */
+    androidCustomSchemeAllowInsecureAccess?: boolean;
   };
 
   /**


### PR DESCRIPTION
add missing information from declarations file for Capacitor 5