### PR TITLE
Update ios-guide.md

### DIFF
--- a/versioned_docs/version-v5/plugins/creating-plugins/ios-guide.md
+++ b/versioned_docs/version-v5/plugins/creating-plugins/ios-guide.md
@@ -264,7 +264,7 @@ let store = CNContactStore()
 
 In most cases, a plugin method will get invoked to perform a task and can finish immediately. But there are situations where you will need to keep the plugin call available so it can be accessed later. You might want to do this to periodically return data such as streaming live geolocation data, or to perform an asynchronous task.
 
-See [this guide on saving plugin calls](/docs/v3/core-apis/saving-calls) for more details on how to persist plugin calls.
+See [this guide on saving plugin calls](/docs/core-apis/saving-calls) for more details on how to persist plugin calls.
 
 ## Error Handling
 


### PR DESCRIPTION
The link in the "Persisting a Plugin Call" section goes to the v3 docs. Change it to just point to current