### PR TITLE
docs: update flavorDimensions syntax

### DIFF
--- a/docs/main/guides/environment-specific-configurations.md
+++ b/docs/main/guides/environment-specific-configurations.md
@@ -112,7 +112,7 @@ Android projects contain multiple `build.gradle` files; the one to modify to set
 Open `/android/app/build.gradle` and add the following code within the `android` block:
 
 ```groovy
-flavorDimensions "environment"
+flavorDimensions = ["environment"]
 productFlavors {
   dev {
       dimension "environment"

--- a/versioned_docs/version-v4/main/guides/environment-specific-configurations.md
+++ b/versioned_docs/version-v4/main/guides/environment-specific-configurations.md
@@ -112,7 +112,7 @@ Android projects contain multiple `build.gradle` files; the one to modify to set
 Open `/android/app/build.gradle` and add the following code within the `android` block:
 
 ```groovy
-flavorDimensions = ["environment"]
+flavorDimensions "environment"
 productFlavors {
   dev {
       dimension "environment"

--- a/versioned_docs/version-v4/main/guides/environment-specific-configurations.md
+++ b/versioned_docs/version-v4/main/guides/environment-specific-configurations.md
@@ -112,7 +112,7 @@ Android projects contain multiple `build.gradle` files; the one to modify to set
 Open `/android/app/build.gradle` and add the following code within the `android` block:
 
 ```groovy
-flavorDimensions "environment"
+flavorDimensions = ["environment"]
 productFlavors {
   dev {
       dimension "environment"

--- a/versioned_docs/version-v5/main/guides/environment-specific-configurations.md
+++ b/versioned_docs/version-v5/main/guides/environment-specific-configurations.md
@@ -112,7 +112,7 @@ Android projects contain multiple `build.gradle` files; the one to modify to set
 Open `/android/app/build.gradle` and add the following code within the `android` block:
 
 ```groovy
-flavorDimensions "environment"
+flavorDimensions = ["environment"]
 productFlavors {
   dev {
       dimension "environment"


### PR DESCRIPTION
`flavorDimensions` with string is deprecated and now it takes an array instead of a string.

Not sure in which version it changed, so I've only updated capacitor 5 and 6 docs since that's where I'm seeing the warning, but have not tried in older versions.