### PR TITLE
docs: fix typo in environment setup

### DIFF
--- a/versioned_docs/version-v5/main/getting-started/environment-setup.md
+++ b/versioned_docs/version-v5/main/getting-started/environment-setup.md
@@ -59,7 +59,7 @@ xcode-select -p
 
 ### Homebrew
 
-Homebrew is a package manager for macOS package. You need to install it in order to install CocoaPods for both Intel and Apple Silicon Macs.
+Homebrew is a package manager for macOS packages. You need to install it in order to install CocoaPods for both Intel and Apple Silicon Macs.
 
 To install Homebrew, run the following bash command:
 


### PR DESCRIPTION
I recommend going with either "macOS packages" (as in this branch) or "macOS" alone.