### PR TITLE
docs: Add note for fully setting up Xcode

### DIFF
--- a/versioned_docs/version-v5/main/getting-started/environment-setup.md
+++ b/versioned_docs/version-v5/main/getting-started/environment-setup.md
@@ -57,6 +57,19 @@ xcode-select -p
 # /Applications/Xcode.app/Contents/Developer
 ```
 
+:::note
+If you encounter the following error while running `npx cap add ios`:
+```bash
+[MT] DVTPlugInLoading: Failed to load code for plug-in
+        com.apple.dt.IDESimulatorAvailability
+```
+
+Then you can open Xcode on your machine and allow any pending installations or updates to complete, or if you prefer doing it within the terminal:
+```bash
+xcodebuild -runFirstLaunch
+```
+:::
+
 ### Homebrew
 
 Homebrew is a package manager for macOS package. You need to install it in order to install CocoaPods for both Intel and Apple Silicon Macs.


### PR DESCRIPTION
When I tried adding capacitor for creating an iOS app, I followed every instructions in the docs but the terminal keep throwing me this error when running the `npx cap add ios`:
```
xcodebuild[71802:36055354] [MT] DVTPlugInLoading: Failed to load code for plug-in
        com.apple.dt.IDESimulatorAvailability
        (/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin), error = Error
        Domain=NSCocoaErrorDomain Code=3588
        "dlopen(/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability,
        0x0109): Library not loaded:
        /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator
        Referenced from: <E13CCC38-A1BB-3A12-B4B3-448542B049C5>
        /Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability
        Reason: tried: '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file),
        '/System/Volumes/Preboot/Cryptexes/OS/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator'
        (no such file), '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file)" UserInfo={NSLocalizedFailureReason=The bundle couldn’t be loaded., NSLocalizedRecoverySuggestion=Try
        reinstalling the bundle.,
        NSFilePath=/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability,
        NSDebugDescription=dlopen(/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability,
        0x0109): Library not loaded:
        /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator
        Referenced from: <E13CCC38-A1BB-3A12-B4B3-448542B049C5>
        /Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability
        Reason: tried: '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file),
        '/System/Volumes/Preboot/Cryptexes/OS/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator'
        (no such file), '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file), NSBundlePath=/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin,
        NSLocalizedDescription=The bundle “IDESimulatorAvailability” couldn’t be loaded.}, dyldError =
        dlopen(/Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability,
        0x0000): Library not loaded:
        /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator
        Referenced from: <E13CCC38-A1BB-3A12-B4B3-448542B049C5>
        /Applications/Xcode.app/Contents/PlugIns/IDESimulatorAvailability.ideplugin/Contents/MacOS/IDESimulatorAvailability
        Reason: tried: '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file),
        '/System/Volumes/Preboot/Cryptexes/OS/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator'
        (no such file), '/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator' (no such
        file)
        
        A required plugin failed to load. Please ensure system content is up-to-date — try running 'xcodebuild
        -runFirstLaunch'.
```

As the output of the error suggested, I run `xcodebuild -runFirstLaunch` and then the `npx cap add ios` worked flawlessly, so I decided to add this to the documentation for other to be aware of this.