### PR TITLE
docs: fix typo in method-types.md

### DIFF
--- a/versioned_docs/version-v5/plugins/creating-plugins/method-types.md
+++ b/versioned_docs/version-v5/plugins/creating-plugins/method-types.md
@@ -25,7 +25,7 @@ export type MyPluginCallback = (message: MyData | null, err?: any) => void;
 export interface MyPlugin {
   method1(): Promise<void>;
   method2(): Promise<MyData>;
-  cmethod3(callback: MyPluginCallback): Promise<CallbackID>;
+  method3(callback: MyPluginCallback): Promise<CallbackID>;
 }
 ```
 


### PR DESCRIPTION
Fix small typo in code example.