### PR TITLE
docs: use latest plugin-migration-v4-to-v5

### DIFF
--- a/docs/main/updating/plugins/5-0.md
+++ b/docs/main/updating/plugins/5-0.md
@@ -25,7 +25,7 @@ To match iOS behavior, `PluginCall.getObject()` and `PluginCall.getArray()` on A
 
 ## Using @capacitor/plugin-migration-v4-to-v5
 
-From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5@latest-5` and it will perform all the file changes automatically.
+From the plugin folder, run `npx @capacitor/plugin-migration-v4-to-v5@latest` and it will perform all the file changes automatically.
 
 ## Updating the files manually
 


### PR DESCRIPTION
There is no `latest-5` of `@capacitor/plugin-migration-v4-to-v5`, the new package is called `@capacitor/plugin-migration-v5-to-v6`, so latest `@capacitor/plugin-migration-v4-to-v5` is still `@capacitor/plugin-migration-v4-to-v5`