### PR TITLE
chore: Update plugin docs generator for Capacitor 6

### DIFF
--- a/docs/apis/device.md
+++ b/docs/apis/device.md
@@ -17,7 +17,40 @@ npm install @capacitor/device
 npx cap sync
 ```
 
-## Example
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
+
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryDiskSpace](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397) and the recommended reason is [85F4.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397).**
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>85F4.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
+## Example Plugin Usage
 
 ```typescript
 import { Device } from '@capacitor/device';

--- a/docs/apis/filesystem.md
+++ b/docs/apis/filesystem.md
@@ -17,9 +17,42 @@ npm install @capacitor/filesystem
 npx cap sync
 ```
 
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
+
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryFileTimestamp](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393) and the recommended reason is [C617.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393).**
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>C617.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
 ## iOS
 
-To have files appear in the Files app, you must set the following keys to `YES` in `Info.plist`:
+To have files appear in the Files app, you must also set the following keys to `YES` in `Info.plist`:
 
 - `UIFileSharingEnabled` (`Application supports iTunes file sharing`)
 - `LSSupportsOpeningDocumentsInPlace` (`Supports opening documents in place`)

--- a/docs/apis/preferences.md
+++ b/docs/apis/preferences.md
@@ -31,7 +31,40 @@ npm install @capacitor/preferences
 npx cap sync
 ```
 
-## Example
+## Apple Privacy Manifest Requirements
+
+Apple mandates that app developers now specify approved reasons for API usage to enhance user privacy. By May 1st, 2024, it's required to include these reasons when submitting apps to the App Store Connect.
+
+When using this specific plugin in your app, you must create a `PrivacyInfo.xcprivacy` file in `/ios/App` or use the VS Code Extension to generate it, specifying the usage reasons.
+
+For detailed steps on how to do this, please see the [Capacitor Docs](https://capacitorjs.com/docs/ios/privacy-manifest).
+
+**For this plugin, the required dictionary key is [NSPrivacyAccessedAPICategoryUserDefaults](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) and the recommended reason is [CA92.1](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401).**
+
+### Example PrivacyInfo.xcprivacy
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <!-- Add this dict entry to the array if the PrivacyInfo file already exists -->
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>
+```
+
+## Example Plugin Usage
 
 ```typescript
 import { Preferences } from '@capacitor/preferences';

--- a/docs/apis/watch.md
+++ b/docs/apis/watch.md
@@ -81,7 +81,7 @@ We're going to add the code that makes Capacitor Watch work in the watch applica
 
 ---
 
-If you are using <b>Xcode 15 Beta 4 or beyond</b> you then need to add the Capacitor Watch Swift Package from your node_modules:
+If you are using <b>Xcode 15 or beyond</b> you then need to add the Capacitor Watch Swift Package from your node_modules:
 
 First go to the project package dependancies
 
@@ -111,20 +111,29 @@ With <b>Xcode 14</b> you will need to go here https://github.com/ionic-team/Capa
 
 Step 6
 
-Then open the watch app's 'Main' file which should be `watchappApp.swift`. Add the line `import WatchConnectivity` above the `@main` statement. Then replace the line that says `ContentView()` with this:
-
-```swift
-CapWatchContentView()
-    .onAppear {
-        assert(WCSession.isSupported(), "This sample requires Watch Connectivity support!")
-        WCSession.default.delegate = WatchViewModel.shared
-        WCSession.default.activate()
-    }
-```
+Then open the watch app's 'Main' file which should be `watchappApp.swift`. Add the lines `import WatchConnectivity` and `import iOS_capWatch_watch`  above the `@main` statement. Then replace the line that says `ContentView()` with this:
 
 The finished file should look like this:
 
-<img src="https://raw.githubusercontent.com/ionic-team/CapacitorWatch/main/img/watch-main-code.png" />
+```swift
+import SwiftUI
+import WatchConnectivity
+import iOS_capWatch_watch
+
+@main
+struct watchddgg_Watch_AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            CapWatchContentView()
+                .onAppear {
+                    assert(WCSession.isSupported(), "This sample requires Watch Connectivity support!")
+                    WCSession.default.delegate = WatchViewModel.shared
+                    WCSession.default.activate()
+                }
+        }
+    }
+}
+```
 
 Step 7
 

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -1,12 +1,11 @@
 // @ts-check
-import path from 'path';
 import fs from 'fs';
 import fetch from 'node-fetch';
 
 // @ts-ignore
 const API_DIR = new URL('../docs/apis/', import.meta.url);
 
-const tag = 'next';
+const tag = 'latest';
 
 /**
  * @typedef {Object} PluginApi
@@ -126,6 +125,7 @@ const pluginApis = [
     npmScope: '@capacitor',
     editUrl: 'https://github.com/ionic-team/capacitor-plugins/blob/main/google-maps/README.md',
     editApiUrl: 'https://github.com/ionic-team/capacitor-plugins/blob/main/google-maps/src/definitions.ts',
+    tag: 'next',
   },
   {
     id: 'haptics',
@@ -283,19 +283,6 @@ function createApiPage(plugin, readme, pkgJson) {
   const editUrl = plugin.editUrl;
   const editApiUrl = plugin.editApiUrl;
   const sidebarLabel = toTitleCase(plugin.id);
-
-  // // escape right curly brace in inline code blocks for MDX v3 compatability
-  // const regexp = /[<|(&lt;)]code>(.*)[<|(&lt;)]\/code>/g;
-
-  // readme = readme.replace(regexp, (result) => {
-  //   return result.replace(/\{/g, '&#123;');
-  // });
-
-  // // @ts-ignore
-  // readme = readme
-  //   .replaceAll(/<!--.*-->/g, '') // removes JSDoc HTML comments as they break docusauurs
-  //   .replaceAll('<->', '&lt;->'); // escape arrow for MDX v3. note: can't escape all arrows due to component tags
-
   return `
 ---
 title: ${title}


### PR DESCRIPTION
Use `latest` instead of `next` in the plugin generator script, except for google maps as `latest` there is still the v5 as it was not released.

Regenerate the files so they include the privacy manifest information.