### PR TITLE
chore: use relative links in update guide

### DIFF
--- a/docs/main/updating/6-0.md
+++ b/docs/main/updating/6-0.md
@@ -167,7 +167,7 @@ For all plugins that had listeners, `addListener` now only returns a `Promise`, 
 
 ### Google Maps
 
-- iOS native libraries have been updated, check [this for more details](https://capacitorjs.com/docs/next/apis/google-maps#ios)
+- iOS native libraries have been updated, check [this for more details](../../apis/google-maps.md#ios)
 - `NSLocationAlwaysUsageDescription` (`Privacy - Location Always Usage Description`) is deprecated and can be removed from the `Info.plist`.
 - `googleMapsPlayServicesVersion` has been updated to `18.2.0`.
 - `googleMapsUtilsVersion` has been updated to `3.8.2`.
@@ -179,7 +179,7 @@ For all plugins that had listeners, `addListener` now only returns a `Promise`, 
 
 ### Local Notifications
 
-- On Android 14 the notifications are not exact by default even if using `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />` permission, see [this for more details](https://capacitorjs.com/docs/next/apis/local-notifications#android)
+- On Android 14 the notifications are not exact by default even if using `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />` permission, see [this for more details](../../apis/local-notifications.md#android)
 
 ### Push Notifications
 


### PR DESCRIPTION
`next` links no longer work, use relative links to the .md files