### PR TITLE
fix: use custom_edit_url instead of editUrl

### DIFF
--- a/docs/apis/action-sheet.md
+++ b/docs/apis/action-sheet.md
@@ -1,7 +1,7 @@
 ---
 title: Action Sheet Capacitor Plugin API
 description: The Action Sheet API provides access to native Action Sheets, which come up from the bottom of the screen and display actions a user can take.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/action-sheet/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/action-sheet/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/action-sheet/src/definitions.ts
 sidebar_label: Action Sheet
 ---

--- a/docs/apis/app-launcher.md
+++ b/docs/apis/app-launcher.md
@@ -1,7 +1,7 @@
 ---
 title: App Launcher Capacitor Plugin API
 description: The AppLauncher API allows to open other apps
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/app-launcher/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/app-launcher/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/app-launcher/src/definitions.ts
 sidebar_label: App Launcher
 ---

--- a/docs/apis/app.md
+++ b/docs/apis/app.md
@@ -1,7 +1,7 @@
 ---
 title: App Capacitor Plugin API
 description: The App API handles high level App state and events.For example, this API emits events when the app enters and leaves the foreground, handles deeplinks, opens other apps, and manages persisted plugin state.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/app/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/app/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/app/src/definitions.ts
 sidebar_label: App
 ---

--- a/docs/apis/background-runner.md
+++ b/docs/apis/background-runner.md
@@ -1,7 +1,7 @@
 ---
 title: Background Runner Capacitor Plugin API
 description: Capacitor Background Runner
-editUrl: https://github.com/ionic-team/capacitor-background-runner/blob/main/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-background-runner/blob/main/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-background-runner/blob/main/packages/capacitor-plugin/src/definitions.ts
 sidebar_label: Background Runner
 ---

--- a/docs/apis/browser.md
+++ b/docs/apis/browser.md
@@ -1,7 +1,7 @@
 ---
 title: Browser Capacitor Plugin API
 description: The Browser API provides the ability to open an in-app browser and subscribe to browser events.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/browser/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/browser/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/browser/src/definitions.ts
 sidebar_label: Browser
 ---

--- a/docs/apis/camera.md
+++ b/docs/apis/camera.md
@@ -1,7 +1,7 @@
 ---
 title: Camera Capacitor Plugin API
 description: The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/camera/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/camera/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/camera/src/definitions.ts
 sidebar_label: Camera
 ---

--- a/docs/apis/clipboard.md
+++ b/docs/apis/clipboard.md
@@ -1,7 +1,7 @@
 ---
 title: Clipboard Capacitor Plugin API
 description: The Clipboard API enables copy and pasting to/from the system clipboard.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/clipboard/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/clipboard/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/clipboard/src/definitions.ts
 sidebar_label: Clipboard
 ---

--- a/docs/apis/cookies.md
+++ b/docs/apis/cookies.md
@@ -1,7 +1,7 @@
 ---
 title: Cookies Capacitor Plugin API
 description: The Capacitor Cookies API provides native cookie support via patching `document.cookie` to use native libraries.
-editUrl: https://github.com/ionic-team/capacitor/blob/main/core/cookies.md
+custom_edit_url: https://github.com/ionic-team/capacitor/blob/main/core/cookies.md
 editApiUrl: https://github.com/ionic-team/capacitor/blob/main/core/src/core-plugins.ts
 sidebar_label: Cookies
 ---

--- a/docs/apis/device.md
+++ b/docs/apis/device.md
@@ -1,7 +1,7 @@
 ---
 title: Device Capacitor Plugin API
 description: The Device API exposes internal information about the device, such as the model and operating system version, along with user information such as unique ids.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/device/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/device/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/device/src/definitions.ts
 sidebar_label: Device
 ---

--- a/docs/apis/dialog.md
+++ b/docs/apis/dialog.md
@@ -1,7 +1,7 @@
 ---
 title: Dialog Capacitor Plugin API
 description: The Dialog API provides methods for triggering native dialog windows for alerts, confirmations, and input prompts
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/dialog/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/dialog/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/dialog/src/definitions.ts
 sidebar_label: Dialog
 ---

--- a/docs/apis/filesystem.md
+++ b/docs/apis/filesystem.md
@@ -1,7 +1,7 @@
 ---
 title: Filesystem Capacitor Plugin API
 description: The Filesystem API provides a NodeJS-like API for working with files on the device.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/filesystem/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/filesystem/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/filesystem/src/definitions.ts
 sidebar_label: Filesystem
 ---

--- a/docs/apis/geolocation.md
+++ b/docs/apis/geolocation.md
@@ -1,7 +1,7 @@
 ---
 title: Geolocation Capacitor Plugin API
 description: The Geolocation API provides simple methods for getting and tracking the current position of the device using GPS, along with altitude, heading, and speed information if available.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/geolocation/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/geolocation/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/geolocation/src/definitions.ts
 sidebar_label: Geolocation
 ---

--- a/docs/apis/google-maps.md
+++ b/docs/apis/google-maps.md
@@ -1,7 +1,7 @@
 ---
 title: Google Maps Capacitor Plugin API
 description: Google maps on Capacitor
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/google-maps/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/google-maps/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/google-maps/src/definitions.ts
 sidebar_label: Google Maps
 ---

--- a/docs/apis/haptics.md
+++ b/docs/apis/haptics.md
@@ -1,7 +1,7 @@
 ---
 title: Haptics Capacitor Plugin API
 description: The Haptics API provides physical feedback to the user through touch or vibration.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/haptics/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/haptics/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/haptics/src/definitions.ts
 sidebar_label: Haptics
 ---

--- a/docs/apis/http.md
+++ b/docs/apis/http.md
@@ -1,7 +1,7 @@
 ---
 title: Http Capacitor Plugin API
 description: The Capacitor Http API provides native http support via patching `fetch` and `XMLHttpRequest` to use native libraries.
-editUrl: https://github.com/ionic-team/capacitor/blob/main/core/http.md
+custom_edit_url: https://github.com/ionic-team/capacitor/blob/main/core/http.md
 editApiUrl: https://github.com/ionic-team/capacitor/blob/main/core/src/core-plugins.ts
 sidebar_label: Http
 ---

--- a/docs/apis/keyboard.md
+++ b/docs/apis/keyboard.md
@@ -1,7 +1,7 @@
 ---
 title: Keyboard Capacitor Plugin API
 description: The Keyboard API provides keyboard display and visibility control, along with event tracking when the keyboard shows and hides.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/keyboard/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/keyboard/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/keyboard/src/definitions.ts
 sidebar_label: Keyboard
 ---

--- a/docs/apis/local-notifications.md
+++ b/docs/apis/local-notifications.md
@@ -1,7 +1,7 @@
 ---
 title: Local Notifications Capacitor Plugin API
 description: The Local Notifications API provides a way to schedule device notifications locally (i.e. without a server sending push notifications).
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/local-notifications/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/local-notifications/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/local-notifications/src/definitions.ts
 sidebar_label: Local Notifications
 ---

--- a/docs/apis/motion.md
+++ b/docs/apis/motion.md
@@ -1,7 +1,7 @@
 ---
 title: Motion Capacitor Plugin API
 description: The Motion API tracks accelerometer and device orientation (compass heading, etc.)
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/motion/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/motion/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/motion/src/definitions.ts
 sidebar_label: Motion
 ---

--- a/docs/apis/network.md
+++ b/docs/apis/network.md
@@ -1,7 +1,7 @@
 ---
 title: Network Capacitor Plugin API
 description: The Network API provides network and connectivity information.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/network/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/network/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/network/src/definitions.ts
 sidebar_label: Network
 ---

--- a/docs/apis/preferences.md
+++ b/docs/apis/preferences.md
@@ -1,7 +1,7 @@
 ---
 title: Preferences Capacitor Plugin API
 description: The Preferences API provides a simple key/value persistent store for lightweight data.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/preferences/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/preferences/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/preferences/src/definitions.ts
 sidebar_label: Preferences
 ---

--- a/docs/apis/push-notifications.md
+++ b/docs/apis/push-notifications.md
@@ -1,7 +1,7 @@
 ---
 title: Push Notifications Capacitor Plugin API
 description: The Push Notifications API provides access to native push notifications.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/push-notifications/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/push-notifications/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/push-notifications/src/definitions.ts
 sidebar_label: Push Notifications
 ---

--- a/docs/apis/screen-orientation.md
+++ b/docs/apis/screen-orientation.md
@@ -1,7 +1,7 @@
 ---
 title: Screen Orientation Capacitor Plugin API
 description: The Screen Orientation API provides methods to lock and unlock the screen orientation.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-orientation/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-orientation/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-orientation/src/definitions.ts
 sidebar_label: Screen Orientation
 ---

--- a/docs/apis/screen-reader.md
+++ b/docs/apis/screen-reader.md
@@ -1,7 +1,7 @@
 ---
 title: Screen Reader Capacitor Plugin API
 description: The Screen Reader API provides access to TalkBack/VoiceOver/etc. and provides simple text-to-speech capabilities for visual accessibility.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-reader/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-reader/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/screen-reader/src/definitions.ts
 sidebar_label: Screen Reader
 ---

--- a/docs/apis/share.md
+++ b/docs/apis/share.md
@@ -1,7 +1,7 @@
 ---
 title: Share Capacitor Plugin API
 description: The Share API provides methods for sharing content in any sharing-enabled apps the user may have installed.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/share/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/share/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/share/src/definitions.ts
 sidebar_label: Share
 ---

--- a/docs/apis/splash-screen.md
+++ b/docs/apis/splash-screen.md
@@ -1,7 +1,7 @@
 ---
 title: Splash Screen Capacitor Plugin API
 description: The Splash Screen API provides methods for showing or hiding a Splash image.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/splash-screen/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/splash-screen/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/splash-screen/src/definitions.ts
 sidebar_label: Splash Screen
 ---

--- a/docs/apis/status-bar.md
+++ b/docs/apis/status-bar.md
@@ -1,7 +1,7 @@
 ---
 title: Status Bar Capacitor Plugin API
 description: The StatusBar API Provides methods for configuring the style of the Status Bar, along with showing or hiding it.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/status-bar/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/status-bar/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/status-bar/src/definitions.ts
 sidebar_label: Status Bar
 ---

--- a/docs/apis/text-zoom.md
+++ b/docs/apis/text-zoom.md
@@ -1,7 +1,7 @@
 ---
 title: Text Zoom Capacitor Plugin API
 description: The Text Zoom API provides the ability to change Web View text size for visual accessibility.
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/text-zoom/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/text-zoom/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/text-zoom/src/definitions.ts
 sidebar_label: Text Zoom
 ---

--- a/docs/apis/toast.md
+++ b/docs/apis/toast.md
@@ -1,7 +1,7 @@
 ---
 title: Toast Capacitor Plugin API
 description: The Toast API provides a notification pop up for displaying important information to a user. Just like real toast!
-editUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/toast/README.md
+custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/toast/README.md
 editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/toast/src/definitions.ts
 sidebar_label: Toast
 ---

--- a/docs/apis/watch.md
+++ b/docs/apis/watch.md
@@ -1,7 +1,7 @@
 ---
 title: Watch Capacitor Plugin API
 description: Provide Watch interfaces and communication
-editUrl: https://github.com/ionic-team/CapacitorWatch/blob/main/README.md
+custom_edit_url: https://github.com/ionic-team/CapacitorWatch/blob/main/README.md
 editApiUrl: https://github.com/ionic-team/CapacitorWatch/blob/main/packages/capacitor-plugin/src/definitions.ts
 sidebar_label: Watch 🧪
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,21 +262,12 @@ module.exports = {
               return 'https://crowdin.com/project/capacitor-docs';
             }
 
-            const apiRegex = /apis\/(.*)\.md/;
-            const apiRegexPath = apiRegex.exec(docPath)?.[1];
-
             const cliRegex = /cli\/commands\/(.*)\.md/;
             const cliRegexPath = cliRegex.exec(docPath)?.[1];
 
             const nativeRegex = /native\/(.*)\.md/;
             const nativeRegexPath = nativeRegex.exec(docPath)?.[1];
 
-            if (apiRegexPath) {
-              if (apiRegexPath === 'cookies' || apiRegexPath === 'http') {
-                return `https://github.com/ionic-team/capacitor-docs/edit/main/docs/apis/${apiRegexPath}.md`;
-              }
-              return `https://github.com/ionic-team/capacitor-plugins/edit/main/${apiRegexPath}/README.md`;
-            }
             if (cliRegexPath) {
               return `https://github.com/ionic-team/capacitor-docs/edit/main/docs/cli/commands/${cliRegexPath.replace(
                 '-',

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -287,7 +287,7 @@ function createApiPage(plugin, readme, pkgJson) {
 ---
 title: ${title}
 description: ${desc}
-editUrl: ${editUrl}
+custom_edit_url: ${editUrl}
 editApiUrl: ${editApiUrl}
 sidebar_label: ${sidebarLabel}${plugin.isExperimental ? ' 🧪' : ''}
 ---


### PR DESCRIPTION
Looks like at some point having `editUrl` on the md files broke and we started using programmatic `editUrl`, but the programmatic `editUrl` doesn't handle all the cases, on the other hand we are also setting the proper edition url on the md files, but for properly override the programmatic `editUrl` it has to be called `custom_edit_url`.

So this PR replaces `editUrl` with `custom_edit_url` in the md files (and the api.mjs that write the md files), and removes the programmatic `editUrl` case for plugins since it's incorrect and not needed with the new `custom_edit_url`.

Fixes http, cookies, background runner and watch plugins links.