### PR TITLE
docs: Update custom code information for Capacitor 6

### DIFF
--- a/docs/main/ios/custom-code.md
+++ b/docs/main/ios/custom-code.md
@@ -29,7 +29,13 @@ Copy the following Swift code into `EchoPlugin.swift`:
 import Capacitor
 
 @objc(EchoPlugin)
-public class EchoPlugin: CAPPlugin {
+public class EchoPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "EchoPlugin"
+    public let jsName = "Echo"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "echo", returnType: CAPPluginReturnPromise)
+    ]
+
     @objc func echo(_ call: CAPPluginCall) {
         let value = call.getString("value") ?? ""
         call.resolve(["value": value])
@@ -43,25 +49,17 @@ public class EchoPlugin: CAPPlugin {
 
 We must register custom plugins on both iOS and web so that Capacitor can bridge between Swift and JavaScript.
 
-#### `EchoPlugin.m`
+#### `MyViewController.swift`
 
-Next, create a `EchoPlugin.m` file with Xcode in the same way, but choose **Objective-C** in the window. Leave the **File Type** as **Empty File**. If prompted by Xcode to create a Bridging Header, click **Create Bridging Header**.
+[Create a custom `MyViewController.swift`](../ios/viewcontroller.md).
 
-> Using Xcode to create native files is recommended because it ensures the references are added to the project appropriately.
->
-> These changes to project files should be committed to your project along with the new files themselves.
+Then add a `capacitorDidLoad()` method override and register the plugin:
 
-Copy the following Swift code into `EchoPlugin.m`:
-
-```objectivec
-#import <Capacitor/Capacitor.h>
-
-CAP_PLUGIN(EchoPlugin, "Echo",
-    CAP_PLUGIN_METHOD(echo, CAPPluginReturnPromise);
-)
+```swift
+override open func capacitorDidLoad() {
+    bridge?.registerPluginInstance(EchoPlugin())
+}
 ```
-
-> These Objective-C macros register your plugin with Capacitor, making `EchoPlugin` and its `echo` method available to JavaScript. Whenever you add or remove methods in `EchoPlugin.swift`, this file must be updated.
 
 #### JavaScript
 

--- a/docs/main/ios/viewcontroller.md
+++ b/docs/main/ios/viewcontroller.md
@@ -9,11 +9,11 @@ slug: /ios/viewcontroller
 
 # Custom ViewController
 
-With Capacitor 3.0, you can now subclass `CAPBridgeViewController` within your application. Most applications do not need this feature but it provides a supported mechanism for addressing some unusual use-cases.
+Since Capacitor 3.0, you can subclass `CAPBridgeViewController` within your application. Most applications do not need this feature but it provides a supported mechanism for addressing some use-cases.
 
 ## When to create a subclass
 
-Some examples of when subclassing would be necessary are overriding Capacitor's configuration values at run-time, changing the properties of the [`WKWebViewConfiguration`](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration), subsituting a custom subclass of [`WKWebView`](https://developer.apple.com/documentation/webkit/wkwebview) for Capacitor to use, integrating a 3rd party SDK that suggests adding code to [`viewDidLoad()`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621495-viewdidload), or manipulating native views before they appear onscreen.
+Some examples of when subclassing would be necessary are overriding Capacitor's configuration values at run-time, changing the properties of the [`WKWebViewConfiguration`](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration), subsituting a custom subclass of [`WKWebView`](https://developer.apple.com/documentation/webkit/wkwebview) for Capacitor to use, integrating a 3rd party SDK that suggests adding code to [`viewDidLoad()`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621495-viewdidload), manipulating native views before they appear onscreen, or [registering custom plugins](../ios/custom-code.md).
 
 If you do need to create a custom subclass, there are a couple of steps to get started.
 


### PR DESCRIPTION
The Objective-C class is no longer needed.
A custom ViewController is needed and call to `registerPluginInstance`.

closes https://github.com/ionic-team/capacitor-docs/issues/275