### PR TITLE
docs: Add register plugin section on migrate guide

### DIFF
--- a/docs/main/updating/6-0.md
+++ b/docs/main/updating/6-0.md
@@ -44,6 +44,11 @@ Capacitor 6 requires Xcode 15.0+.
 
 Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
 
+### Removal of automatic plugin registration
+
+In Capacitor 6, plugin classes are no longer automatically registered. For npm installed plugins, the CLI will generate a list of plugin classes to register them programmatically.
+But users using plugins not distributed through npm will have to create [a custom view controller and call register for their plugin classes](../ios/custom-code.md#register-the-plugin).
+
 ## Android
 
 The following guide describes how to upgrade your Capacitor 5 Android project to Capacitor 6.

--- a/docs/main/updating/6-0.md
+++ b/docs/main/updating/6-0.md
@@ -44,10 +44,10 @@ Capacitor 6 requires Xcode 15.0+.
 
 Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
 
-### Removal of automatic plugin registration
+### Register custom plugins
 
 In Capacitor 6, plugin classes are no longer automatically registered. For npm installed plugins, the CLI will generate a list of plugin classes to register them programmatically.
-But users using plugins not distributed through npm will have to create [a custom view controller and call register for their plugin classes](../ios/custom-code.md#register-the-plugin).
+But users following the [custom code guide](../ios/custom-code.md) for creating local plugins not distributed through npm, they will have to create [a custom view controller and register their plugins](../ios/custom-code.md#register-the-plugin).
 
 ## Android
 


### PR DESCRIPTION
There have been several issues and complains from people using custom plugins that no longer work in Capacitor 6 since the automatic plugin registration was removed.
I updated the custom code guide in a previous guide, but it should be mentioned in the upgrade guide too.