### PR TITLE
docs: Update creating plugins guide for new structure

### DIFF
--- a/docs/plugins/creating-plugins/development-workflow.md
+++ b/docs/plugins/creating-plugins/development-workflow.md
@@ -66,7 +66,7 @@ public void openMap(PluginCall call) {
 }
 ```
 
-Implement [iOS functionality](./ios) in `ios/Plugin/EchoPlugin.swift`:
+Implement [iOS functionality](./ios) in `ios/Sources/EchoPlugin/EchoPlugin.swift`:
 
 ```swift
 @objc func openMap(_ call: CAPPluginCall) {
@@ -79,7 +79,7 @@ Implement [iOS functionality](./ios) in `ios/Plugin/EchoPlugin.swift`:
 }
 ```
 
-> Remember to [register plugin methods](/plugins/creating-plugins/ios-guide.md#export-to-capacitor) in your `.m` file.
+> Remember to [register plugin methods](/plugins/creating-plugins/ios-guide.md#export-to-capacitor) in your `.swift` file.
 
 This example contains the most common type of method in plugins but details about all the supported types [can be found here.](/plugins/creating-plugins/method-types.md)
 


### PR DESCRIPTION
There have been several reports of the plugin guide being out of date or incorrect because the plugin generator now creates SPM ready plugins, but the docs still refer to the `.m` classes and `.xcworkspace` file.

This PR updates the guide to only refer `.swift` files and the new SPM structure of the plugins.
Also adds information about the implementation class since it's been around for a few years already and the guide doesn't mention it and can be confusing since we talk about a single file but there are two.

related: https://github.com/ionic-team/create-capacitor-plugin/issues/103