### PR TITLE
docs: Add CLI - cap doctor command to docs

### DIFF
--- a/docs/cli/commands/doctor.md
+++ b/docs/cli/commands/doctor.md
@@ -1,0 +1,19 @@
+---
+title: CLI Command - cap doctor
+description: Capacitor CLI - cap doctor
+contributors:
+  - shouzhi
+sidebar_label: doctor
+---
+
+# Capacitor CLI - cap doctor
+
+Checks the current setup for common errors.
+
+```bash
+npx cap doctor [<platform>]
+```
+
+<strong>Inputs:</strong>
+
+- `platform` (optional): `android`, `ios`


### PR DESCRIPTION
This commit adds a new file, **doctor.md**  to the _docs/cli/command_.
This file provides instructions on how to use the doctor command to check the current Capacitor setup for common errors.