### PR TITLE
replaced link to archived vs code extension issues page to current one

### DIFF
--- a/docs/main/ios/privacy-manifest.md
+++ b/docs/main/ios/privacy-manifest.md
@@ -37,7 +37,7 @@ The extension will then list all changes needed as recommendations titled *Missi
 
 You must select one of the reason codes to explain how you use the plugin. If you are unsure, click *Docs* to go to the Apple’s documentation on the explanations of each reason code.
 
-Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-extension/issues).
+Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-ionic/issues).
 
 ### Manual Steps
 

--- a/docs/main/vs-code-ext/recommendations.md
+++ b/docs/main/vs-code-ext/recommendations.md
@@ -24,5 +24,5 @@ The follow scenarios will show a recommendation:
 - When a plugin is not required (eg `cordova-plugin-add-swift-support`)
 
 :::note
-Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-extension/issues).
+Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-ionic/issues).
 :::

--- a/versioned_docs/version-v4/main/ios/privacy-manifest.md
+++ b/versioned_docs/version-v4/main/ios/privacy-manifest.md
@@ -37,7 +37,7 @@ The extension will then list all changes needed as recommendations titled *Missi
 
 You must select one of the reason codes to explain how you use the plugin. If you are unsure, click *Docs* to go to the Apple’s documentation on the explanations of each reason code.
 
-Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-extension/issues).
+Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-ionic/issues).
 
 ### Manual Steps
 

--- a/versioned_docs/version-v4/main/vs-code-ext/recommendations.md
+++ b/versioned_docs/version-v4/main/vs-code-ext/recommendations.md
@@ -24,5 +24,5 @@ The follow scenarios will show a recommendation:
 - When a plugin is not required (eg `cordova-plugin-add-swift-support`)
 
 :::note
-Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-extension/issues).
+Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-ionic/issues).
 :::

--- a/versioned_docs/version-v5/main/ios/privacy-manifest.md
+++ b/versioned_docs/version-v5/main/ios/privacy-manifest.md
@@ -37,7 +37,7 @@ The extension will then list all changes needed as recommendations titled *Missi
 
 You must select one of the reason codes to explain how you use the plugin. If you are unsure, click *Docs* to go to the Apple’s documentation on the explanations of each reason code.
 
-Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-extension/issues).
+Please note that the VS Code extension has a set of rules for known plugins to help you. If you are still being rejected by Apple for missing privacy manifest reasons it may be that you are using a plugin that the extension does not know. You can open an issue on the [VS Code extension issue tracker](https://github.com/ionic-team/vscode-ionic/issues).
 
 ### Manual Steps
 

--- a/versioned_docs/version-v5/main/vs-code-ext/recommendations.md
+++ b/versioned_docs/version-v5/main/vs-code-ext/recommendations.md
@@ -24,5 +24,5 @@ The follow scenarios will show a recommendation:
 - When a plugin is not required (eg `cordova-plugin-add-swift-support`)
 
 :::note
-Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-extension/issues).
+Not all scenarios are covered, so if there a fix you've needed to apply to your project that you think would be of benefit to other developers please [submit a suggestion](https://github.com/ionic-team/vscode-ionic/issues).
 :::


### PR DESCRIPTION
The links to the VS Code extension issues page were to the archived version (https://github.com/ionic-team/vscode-extension/issues), they are replaced with the active version (https://github.com/ionic-team/vscode-ionic/issues)