### PR TITLE
chore: typo in pwa-elements.mdx

### DIFF
--- a/docs/main/web/pwa-elements.mdx
+++ b/docs/main/web/pwa-elements.mdx
@@ -13,7 +13,7 @@ Some Capacitor plugins, such as `Camera` or `Toast`, have web-based UI available
 
 <img src={require('/img/v6/docs/pwa-elements.png').default} style={{height: "200px"}} />
 
-This UI is implemented using web components. Due the elements being encapsulated by the [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), these components should not conflict
+This UI is implemented using web components. Due to the elements being encapsulated by the [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), these components should not conflict
 with your own UI.
 
 ## Installation


### PR DESCRIPTION
There is a small typo on line 16:

 "Due the elements" -> "Due to the elements"