### PR TITLE
Update docs now that browser close is supported on android

### DIFF
--- a/docs/apis/browser.md
+++ b/docs/apis/browser.md
@@ -76,9 +76,7 @@ Open a page with the specified options.
 close() => Promise<void>
 ```
 
-Web & iOS only: Close an open browser window.
-
-No-op on other platforms.
+Close an open browser window.
 
 **Since:** 1.0.0
 


### PR DESCRIPTION
Support for browser close on android was added here:
https://github.com/ionic-team/capacitor-plugins/pull/1972

Also see: https://github.com/ionic-team/capacitor-plugins/pull/2197