### PR TITLE
docs: update Nx section in monorepos.md

### DIFF
--- a/docs/main/vs-code-ext/monorepos.md
+++ b/docs/main/vs-code-ext/monorepos.md
@@ -12,7 +12,7 @@ The extension supports many flavors of mono-repos and when detecting a monorepo 
 
 ## Supported Types
 The list of supported Monorepo types include:
-- **[NX](https://nx.dev/)** - which is often combined with [nxtend](https://nxtend.dev/docs/capacitor/overview) for Capacitor support
+- **[Nx](https://nx.dev/)** - which is often combined with [Nxext](https://nxext.github.io/nx-extensions-ionic/docs/capacitor/overview.html) for Capacitor support
 - **[NPM Workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces)** - Simple multi project support built into npm.
 - **[Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)** - Multi project support for [Yarn](https://yarnpkg.com/) (an alternative to npm).
 - **[Pnpm Workspaces](https://pnpm.io/workspaces)** - Multi project support for [pnpm](https://pnpm.io/) (an alternative to npm).

--- a/docs/main/vs-code-ext/monorepos.md
+++ b/docs/main/vs-code-ext/monorepos.md
@@ -12,7 +12,7 @@ The extension supports many flavors of mono-repos and when detecting a monorepo 
 
 ## Supported Types
 The list of supported Monorepo types include:
-- **[Nx](https://nx.dev/)** - which is often combined with [Nxext](https://nxext.github.io/nx-extensions-ionic/docs/capacitor/overview.html) for Capacitor support
+- **[Nx](https://nx.dev/)** - which is often combined with [Nxext](https://nxext.dev/docs/nxext/overview.html) for Capacitor support
 - **[NPM Workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces)** - Simple multi project support built into npm.
 - **[Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)** - Multi project support for [Yarn](https://yarnpkg.com/) (an alternative to npm).
 - **[Pnpm Workspaces](https://pnpm.io/workspaces)** - Multi project support for [pnpm](https://pnpm.io/) (an alternative to npm).


### PR DESCRIPTION
Hi, 

Since the Nxtend plugin is not maintained anymore, I suggest updating the docs accordingly. 
Here's [the related discussion](https://x.com/edbzn/status/1837783145128595930) with Dominik, the maintainer.