### PR TITLE
Added missing android usesCleartextTraffic info

### DIFF
--- a/docs/main/guides/live-reload.md
+++ b/docs/main/guides/live-reload.md
@@ -69,3 +69,5 @@ npx cap open android
 Finally, click the Run button to launch the app and start using Live Reload.
 
 > Be careful not to commit the server config to source control.
+
+On android, make sure to add `android:usesCleartextTraffic="true"` inside the `application` properties in `AndroidManifest.xml` or the app won't be able to connect via HTTP.


### PR DESCRIPTION
By default if we follow the tutorial for hot reload and try to run our app, it won't be able to connect to the server via its IP as it's using HTTP. To enable HTTP requests we need to add `android:usesCleartextTraffic="true"` in the manifest.