### PR TITLE
docs: Update Capacitor 7 supported SDK/IDE versions

### DIFF
--- a/docs/main/android/index.md
+++ b/docs/main/android/index.md
@@ -16,7 +16,7 @@ Capacitor Android apps are configured and managed through Android Studio.
 
 ## Android Support
 
-API 22+ (Android 5.1 or later) is supported, which represents [over 99% of the Android market](https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide). Capacitor requires an Android WebView with Chrome version 60 or later. On Android 5-6, and 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView.
+API 23+ (Android 6 or later) is supported, which represents arround 99% of the Android market. Capacitor requires an Android WebView with Chrome version 60 or later. On Android 6, and 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView.
 
 ## Adding the Android Platform
 
@@ -46,7 +46,7 @@ Alternatively, you can open Android Studio and import the `android/` directory a
 
 You can either run your app on the command-line or with Android Studio.
 
-> To use an Android Emulator you must use an API 24+ system image. The System WebView does not automatically update on emulators. Physical devices should work as low as API 21 as long as their System WebView is updated.
+> To use an Android Emulator you must use an API 24+ system image. The System WebView does not automatically update on emulators. Physical devices should work as low as API 23 as long as their System WebView is updated.
 
 ### Running on the Command-Line
 

--- a/docs/main/android/index.md
+++ b/docs/main/android/index.md
@@ -16,7 +16,7 @@ Capacitor Android apps are configured and managed through Android Studio.
 
 ## Android Support
 
-API 23+ (Android 6 or later) is supported, which represents arround 99% of the Android market. Capacitor requires an Android WebView with Chrome version 60 or later. On Android 6, and 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView.
+API 23+ (Android 6 or later) is supported, which represents around 99% of the Android market. Capacitor requires an Android WebView with Chrome version 60 or later. On Android 6, and 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview). On Android 7-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView.
 
 ## Adding the Android Platform
 

--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -14,7 +14,7 @@ Do you need to support Desktops? You can use Capacitor to build [Windows](https:
 
 ## Core Requirements
 
-In order to develop any application with Capacitor, you will need NodeJS 18 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
+In order to develop any application with Capacitor, you will need NodeJS 20 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
 
 Once you have installed Node, open your terminal of choice and type in the following command to make sure node is properly installed
 
@@ -40,7 +40,7 @@ Once you've installed the core requirements, as well as Xcode, Xcode Command Lin
 
 ### Xcode
 
-Xcode is Apple's IDE for creating native macOS, iOS, and iPadOS applications. You can install Xcode by [using the Apple App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) on your Mac. Capacitor 6 requires a minimum of Xcode 15.0.
+Xcode is Apple's IDE for creating native macOS, iOS, and iPadOS applications. You can install Xcode by [using the Apple App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) on your Mac. Capacitor 7 requires a minimum of Xcode 16.0.
 
 ### Xcode Command Line Tools
 
@@ -124,16 +124,16 @@ Once you've installed the core requirements, as well as an Android SDK with Andr
 
 ### Android Studio
 
-Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 6 requires a minimum of Android Studio 2023.1.1.
+Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 6 requires a minimum of Android Studio 2024.2.1.
 
 ### Android SDK
 
 Once Android Studio has been installed, you need to install an Android SDK package.
 
-Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 22 or greater.
+Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 23 or greater.
 
 In Android Studio, open **Tools -> SDK Manager** from the menu and install the platform versions you'd like to test with in the **SDK Platforms** tab:
 
 ![SDK Platforms](/img/v6/docs/android/sdk-platforms.png)
 
-To get started, you only need to install one API version. In the above image, the SDKs for Android 9 (API 28) and Android 10 (API 29) are installed. The latest stable version is Android 14 (API 34).
+To get started, you only need to install one API version. In the above image, the SDKs for Android 9 (API 28) and Android 10 (API 29) are installed. The latest stable version is Android 15 (API 35).

--- a/docs/main/ios/index.md
+++ b/docs/main/ios/index.md
@@ -15,7 +15,7 @@ Capacitor iOS apps are configured and managed with Xcode and [CocoaPods](https:/
 
 ## iOS Support
 
-iOS 13+ is supported. Xcode 15.0+ is required (see [Environment Setup](/main/getting-started/environment-setup.md#ios-requirements)). Capacitor uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview), not the deprecated [UIWebView](https://developer.apple.com/documentation/uikit/uiwebview).
+iOS 14+ is supported. Xcode 16.0+ is required (see [Environment Setup](/main/getting-started/environment-setup.md#ios-requirements)). Capacitor uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview), not the deprecated [UIWebView](https://developer.apple.com/documentation/uikit/uiwebview).
 
 ## Adding the iOS Platform
 

--- a/docs/main/reference/support-policy.mdx
+++ b/docs/main/reference/support-policy.mdx
@@ -22,6 +22,7 @@ The current status of each Capacitor version is:
 
 | Version |      Status      |    Released    | Maintenance Ends  | Ext. Support Ends |
 | :-----: | :--------------: | :------------: | :---------------: | :---------------: |
+|   V7    |    **Active**    |      TBD       |        TBD        |        TBD        |
 |   V6    |    **Active**    | April 15, 2024 |        TBD        |        TBD        |
 |   V5    | Extended Support |   May 3, 2023  | October 15, 2024  |  April 15, 2025   |
 |   V4    |  End of Support  |  July 27, 2022 | November 3, 2023  |    May 3, 2024    |
@@ -38,6 +39,7 @@ The Capacitor team has compiled a set of recommendations for using the Capacitor
 
 | Capacitor | Minimum Node Version | Minimum Xcode Version | Minimum Android Studio Version |
 | :-------: | :------------------: | :-------------------: | :----------------------------: |
+|    v7     |          20          |         16.0          |            2024.2.1            |
 |    v6     |          18          |         15.0          |            2023.1.1            |
 |    v5     |          16          |         14.1          |            2022.2.1            |
 |    v4     |          12          |          13           |             2020.1             |
@@ -49,6 +51,7 @@ Each Capacitor version sets a minimum version for each of its supported platform
 
 | Capacitor | Minimum iOS Version | Minimum Android Version |
 | :-------: | :-----------------: | :---------------------: |
+|    v7     |        14.0         |      6.0 (API 23)       |
 |    v6     |        13.0         |      5.1 (API 22)       |
 |    v5     |        13.0         |      5.1 (API 22)       |
 |    v4     |        13.0         |      5.1 (API 22)       |


### PR DESCRIPTION
Update support page to include information about Capacitor 7.
Edit iOS/android/requirements pages to update information about supported SDKs and IDEs required versions.