### PR TITLE
fix(ios): Update link in ios configuration.md

### DIFF
--- a/versioned_docs/version-v2/ios/configuration.md
+++ b/versioned_docs/version-v2/ios/configuration.md
@@ -57,7 +57,7 @@ Here you can click on the name "App" under TARGET to rename your app.
 
 You then also have to modify the Podfile to rename the current target accordingly:
 
-The default Podfile has an `'App'` target, which needs to be replaced with <a href="https://github.com/ionic-team/capacitor/blob/master/ios-template/App/Podfile#L16" target="_blank">your new name here.</a>
+The default Podfile has an `'App'` target, which needs to be replaced with <a href="https://github.com/ionic-team/capacitor/blob/main/ios-pods-template/App/Podfile#L16" target="_blank">your new name here.</a>
 
 ## Deeplinks (aka Universal Links)
 


### PR DESCRIPTION
This fixes the link in the `Renaming the application's default App name` section of the docs to point to the podfile at the right place