### PR TITLE
chore: use versioned github links

### DIFF
--- a/docs/main/ios/troubleshooting.md
+++ b/docs/main/ios/troubleshooting.md
@@ -114,6 +114,6 @@ First of all, make sure the plugin is installed and appears in the `package.json
 
 Then, run `npx cap sync ios`.
 
-Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-pods-template/App/Podfile) and run `npx cap sync` again.
 
 If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.

--- a/versioned_docs/version-v2/android/configuration.md
+++ b/versioned_docs/version-v2/android/configuration.md
@@ -86,4 +86,4 @@ Generally, the plugin you choose to use will ask you to set a permission. Add it
 
 ## Default Permissions
 
-By default, the entire initial permissions requested for the latest version of Capacitor with the standard plugins can be found in the android-template's [AndroidManifest.xml](https://github.com/ionic-team/capacitor/blob/main/android-template/app/src/main/AndroidManifest.xml)
+By default, the entire initial permissions requested for the latest version of Capacitor with the standard plugins can be found in the android-template's [AndroidManifest.xml](https://github.com/ionic-team/capacitor/blob/2.x/android-template/app/src/main/AndroidManifest.xml)

--- a/versioned_docs/version-v2/android/troubleshooting.md
+++ b/versioned_docs/version-v2/android/troubleshooting.md
@@ -93,7 +93,7 @@ To do this, follow these steps:
 
 ProGuard is a tool used to shrink, obfuscate, and reduce the size of your app. It is enabled by setting the `minifyEnabled` option in `build.gradle` to `true`. This process can sometimes lead to issues in Capacitor when using a plugin or some custom native code that relies on its code being being readable at run time, such as code reflection. ProGuard scans code to try and optimize and shink the size of an app and sometimes this process can remove classes or methods that are important for the functionality of a plugin.
 
-Add [the following rules](https://github.com/ionic-team/capacitor/blob/main/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
+Add [the following rules](https://github.com/ionic-team/capacitor/blob/2.x/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
 
 If you still encounter any issues after adding those rules, try to identify the source plugin or native code and add a rule to cover the specific plugin code, for example:
 

--- a/versioned_docs/version-v3/main/android/troubleshooting.md
+++ b/versioned_docs/version-v3/main/android/troubleshooting.md
@@ -108,7 +108,7 @@ If still getting the "Plugin not implemented" error, make sure you are not using
 
 ProGuard is a tool used to shrink, obfuscate, and reduce the size of your app. It is enabled by setting the `minifyEnabled` option in `build.gradle` to `true`. This process can sometimes lead to issues in Capacitor when using a plugin or some custom native code that relies on its code being being readable at run time, such as code reflection. ProGuard scans code to try and optimize and shink the size of an app and sometimes this process can remove classes or methods that are important for the functionality of a plugin.
 
-As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/main/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
+As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/3.x/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
 
 If you still encounter any issues after adding those rules, try to identify the source plugin or native code and add a rule to cover the specific plugin code, for example:
 

--- a/versioned_docs/version-v3/main/ios/troubleshooting.md
+++ b/versioned_docs/version-v3/main/ios/troubleshooting.md
@@ -114,6 +114,6 @@ First of all, make sure the plugin is installed and appears in the `package.json
 
 Then, run `npx cap sync ios`.
 
-Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/3.x/ios-template/App/Podfile) and run `npx cap sync` again.
 
 If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.

--- a/versioned_docs/version-v3/main/ios/viewcontroller.md
+++ b/versioned_docs/version-v3/main/ios/viewcontroller.md
@@ -47,4 +47,4 @@ You're done!
 
 ### Next Steps
 
-Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.
+Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/3.x/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.

--- a/versioned_docs/version-v3/main/updating/3-0.md
+++ b/versioned_docs/version-v3/main/updating/3-0.md
@@ -452,7 +452,7 @@ The `androidxEspressoCoreVersion` can be updated to `3.3.0`.
 
 ### Remove unused and redundant permissions
 
-Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/main/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
+Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/3.x/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
 
 1. Determine the plugins that your app uses
 1. Read the installation instructions of each plugin [in these docs](/plugins/official.md), looking for permissions that each plugin requires

--- a/versioned_docs/version-v4/main/android/troubleshooting.md
+++ b/versioned_docs/version-v4/main/android/troubleshooting.md
@@ -124,7 +124,7 @@ If still getting the "Plugin not implemented" error, make sure you are not using
 
 ProGuard is a tool used to shrink, obfuscate, and reduce the size of your app. It is enabled by setting the `minifyEnabled` option in `build.gradle` to `true`. This process can sometimes lead to issues in Capacitor when using a plugin or some custom native code that relies on its code being being readable at run time, such as code reflection. ProGuard scans code to try and optimize and shink the size of an app and sometimes this process can remove classes or methods that are important for the functionality of a plugin.
 
-As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/main/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
+As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/4.x/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
 
 If you still encounter any issues after adding those rules, try to identify the source plugin or native code and add a rule to cover the specific plugin code, for example:
 

--- a/versioned_docs/version-v4/main/ios/troubleshooting.md
+++ b/versioned_docs/version-v4/main/ios/troubleshooting.md
@@ -114,6 +114,6 @@ First of all, make sure the plugin is installed and appears in the `package.json
 
 Then, run `npx cap sync ios`.
 
-Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/4.x/ios-template/App/Podfile) and run `npx cap sync` again.
 
 If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.

--- a/versioned_docs/version-v4/main/ios/viewcontroller.md
+++ b/versioned_docs/version-v4/main/ios/viewcontroller.md
@@ -47,4 +47,4 @@ You're done!
 
 ### Next Steps
 
-Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.
+Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/4.x/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.

--- a/versioned_docs/version-v4/main/updating/3-0.md
+++ b/versioned_docs/version-v4/main/updating/3-0.md
@@ -452,7 +452,7 @@ The `androidxEspressoCoreVersion` can be updated to `3.3.0`.
 
 ### Remove unused and redundant permissions
 
-Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/main/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
+Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/4.x/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
 
 1. Determine the plugins that your app uses
 1. Read the installation instructions of each plugin [in these docs](/plugins/official.md), looking for permissions that each plugin requires

--- a/versioned_docs/version-v5/main/android/troubleshooting.md
+++ b/versioned_docs/version-v5/main/android/troubleshooting.md
@@ -124,7 +124,7 @@ If still getting the "Plugin not implemented" error, make sure you are not using
 
 ProGuard is a tool used to shrink, obfuscate, and reduce the size of your app. It is enabled by setting the `minifyEnabled` option in `build.gradle` to `true`. This process can sometimes lead to issues in Capacitor when using a plugin or some custom native code that relies on its code being being readable at run time, such as code reflection. ProGuard scans code to try and optimize and shink the size of an app and sometimes this process can remove classes or methods that are important for the functionality of a plugin.
 
-As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/main/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
+As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/5.x/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
 
 If you still encounter any issues after adding those rules, try to identify the source plugin or native code and add a rule to cover the specific plugin code, for example:
 

--- a/versioned_docs/version-v5/main/ios/troubleshooting.md
+++ b/versioned_docs/version-v5/main/ios/troubleshooting.md
@@ -114,6 +114,6 @@ First of all, make sure the plugin is installed and appears in the `package.json
 
 Then, run `npx cap sync ios`.
 
-Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/5.x/ios-template/App/Podfile) and run `npx cap sync` again.
 
 If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.

--- a/versioned_docs/version-v5/main/ios/viewcontroller.md
+++ b/versioned_docs/version-v5/main/ios/viewcontroller.md
@@ -47,4 +47,4 @@ You're done!
 
 ### Next Steps
 
-Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.
+Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/5.x/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.

--- a/versioned_docs/version-v5/main/updating/3-0.md
+++ b/versioned_docs/version-v5/main/updating/3-0.md
@@ -452,7 +452,7 @@ The `androidxEspressoCoreVersion` can be updated to `3.3.0`.
 
 ### Remove unused and redundant permissions
 
-Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/main/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
+Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/5.x/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
 
 1. Determine the plugins that your app uses
 1. Read the installation instructions of each plugin [in these docs](/plugins/official.md), looking for permissions that each plugin requires

--- a/versioned_docs/version-v6/main/android/troubleshooting.md
+++ b/versioned_docs/version-v6/main/android/troubleshooting.md
@@ -124,7 +124,7 @@ If still getting the "Plugin not implemented" error, make sure you are not using
 
 ProGuard is a tool used to shrink, obfuscate, and reduce the size of your app. It is enabled by setting the `minifyEnabled` option in `build.gradle` to `true`. This process can sometimes lead to issues in Capacitor when using a plugin or some custom native code that relies on its code being being readable at run time, such as code reflection. ProGuard scans code to try and optimize and shink the size of an app and sometimes this process can remove classes or methods that are important for the functionality of a plugin.
 
-As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/main/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
+As of Capacitor v3.2.3 there are ProGuard rules included in Capacitor that cover the core functionality of Capacitor plugins, permissions, and activity results. If you are using an earlier version of Capacitor than v3.2.3, add [the following rules](https://github.com/ionic-team/capacitor/blob/6.x/android/capacitor/proguard-rules.pro) to your Android project's `proguard-rules.pro` file. Those rules should resolve problems with any of the core Capacitor features and core plugins.
 
 If you still encounter any issues after adding those rules, try to identify the source plugin or native code and add a rule to cover the specific plugin code, for example:
 

--- a/versioned_docs/version-v6/main/ios/troubleshooting.md
+++ b/versioned_docs/version-v6/main/ios/troubleshooting.md
@@ -114,6 +114,6 @@ First of all, make sure the plugin is installed and appears in the `package.json
 
 Then, run `npx cap sync ios`.
 
-Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/6.x/ios-pods-template/App/Podfile) and run `npx cap sync` again.
 
 If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.

--- a/versioned_docs/version-v6/main/ios/viewcontroller.md
+++ b/versioned_docs/version-v6/main/ios/viewcontroller.md
@@ -47,4 +47,4 @@ You're done!
 
 ### Next Steps
 
-Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.
+Xcode should have already created a `viewDidLoad()` method for you when it generated the file but look over the inline documentation in [`CAPBridgeViewController`](https://github.com/ionic-team/capacitor/blob/6.x/ios/Capacitor/Capacitor/CAPBridgeViewController.swift) to find the Capacitor-specific methods you might need. Anything marked `open` is explicitly exposed for subclasses to override.

--- a/versioned_docs/version-v6/main/updating/3-0.md
+++ b/versioned_docs/version-v6/main/updating/3-0.md
@@ -452,7 +452,7 @@ The `androidxEspressoCoreVersion` can be updated to `3.3.0`.
 
 ### Remove unused and redundant permissions
 
-Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/main/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
+Depending on which plugins you are using, you can optionally remove unused permissions from your app's `AndroidManifest.xml` file. [The manifest in new Capacitor apps](https://github.com/ionic-team/capacitor/blob/6.x/android-template/app/src/main/AndroidManifest.xml) only includes `INTERNET` because permissions are now meant to be added when plugins are installed. Follow these steps to remove unused permissions:
 
 1. Determine the plugins that your app uses
 1. Read the installation instructions of each plugin [in these docs](/plugins/official.md), looking for permissions that each plugin requires


### PR DESCRIPTION
There are several links to Capacitor repository to main branch, since that could change at any moment, I've replaced the links on the versioned docs to point to the branch of the version they are for.

Also fixed a broken link to the ios template on main since it was renamed.