### PR TITLE
chore(versions): make v7 current

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -283,11 +283,10 @@ module.exports = {
           },
           breadcrumbs: false,
           exclude: ['README.md'],
-          lastVersion: 'v6',
+          lastVersion: 'current',
           versions: {
             current: {
               label: 'v7',
-              banner: 'unreleased'
             },
           },
         },

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,8 @@
   "redirects": [
     { "source": "/", "destination": "/docs" },
     { "source": "/docs/apis/storage", "destination": "/docs/apis/preferences" },
-    { "source": "/docs/cli/commands/list", "destination": "/docs/cli/commands/ls" }
+    { "source": "/docs/cli/commands/list", "destination": "/docs/cli/commands/ls" },
+    { "source": "/docs/next/:match*", "destination": "/docs/:match*" }
   ],
   "rewrites": [
     { "source": "/docs", "destination": "/" },


### PR DESCRIPTION
This PR:
- makes v7 the current version
- adds a redirect for all `/next` pages to current