### PR TITLE
docs: point template master branch links to 2.x

### DIFF
--- a/versioned_docs/version-v2/android/updating.md
+++ b/versioned_docs/version-v2/android/updating.md
@@ -22,7 +22,7 @@ Then from Android Studio click the "Sync Project with Gradle Files" button.
 
 ## Updating Android Project
 
-To update the base structure of your Android project, view the [android-template](https://github.com/ionic-team/capacitor/tree/master/android-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.
+To update the base structure of your Android project, view the [android-template](https://github.com/ionic-team/capacitor/tree/2.x/android-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.
 
 ### From 1.0.0 to 1.1.0
 

--- a/versioned_docs/version-v2/android/updating.md
+++ b/versioned_docs/version-v2/android/updating.md
@@ -80,7 +80,7 @@ Recommended changes:
   }
   ```
 
-  In `android/build.gradle` file, add `apply from: "variables.gradle"` as shown [here](https://github.com/ionic-team/capacitor/blob/master/android-template/build.gradle#L18).
+  In `android/build.gradle` file, add `apply from: "variables.gradle"` as shown [here](https://github.com/ionic-team/capacitor/blob/2.x/android-template/build.gradle#L18).
 
 - Use common variables
 

--- a/versioned_docs/version-v2/ios/configuration.md
+++ b/versioned_docs/version-v2/ios/configuration.md
@@ -57,7 +57,7 @@ Here you can click on the name "App" under TARGET to rename your app.
 
 You then also have to modify the Podfile to rename the current target accordingly:
 
-The default Podfile has an `'App'` target, which needs to be replaced with <a href="https://github.com/ionic-team/capacitor/blob/master/ios-template/App/Podfile#L16" target="_blank">your new name here.</a>
+The default Podfile has an `'App'` target, which needs to be replaced with <a href="https://github.com/ionic-team/capacitor/blob/2.x/ios-template/App/Podfile#L16" target="_blank">your new name here.</a>
 
 ## Deeplinks (aka Universal Links)
 

--- a/versioned_docs/version-v2/ios/updating.md
+++ b/versioned_docs/version-v2/ios/updating.md
@@ -27,7 +27,7 @@ npx cap sync ios
 
 To update the base structure of your Xcode project, view the [ios-template](https://github.com/ionic-team/capacitor/tree/master/ios-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.
 
-In particular, [AppDelegate.swift](https://github.com/ionic-team/capacitor/blob/master/ios-template/App/App/AppDelegate.swift) should be checked regularly for possible changes to iOS events.
+In particular, [AppDelegate.swift](https://github.com/ionic-team/capacitor/blob/2.x/ios-template/App/App/AppDelegate.swift) should be checked regularly for possible changes to iOS events.
 
 ### From 1.0.0 to 1.1.0
 

--- a/versioned_docs/version-v2/ios/updating.md
+++ b/versioned_docs/version-v2/ios/updating.md
@@ -25,7 +25,7 @@ npx cap sync ios
 
 ## Updating iOS Project
 
-To update the base structure of your Xcode project, view the [ios-template](https://github.com/ionic-team/capacitor/tree/master/ios-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.
+To update the base structure of your Xcode project, view the [ios-template](https://github.com/ionic-team/capacitor/tree/2.x/ios-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.
 
 In particular, [AppDelegate.swift](https://github.com/ionic-team/capacitor/blob/2.x/ios-template/App/App/AppDelegate.swift) should be checked regularly for possible changes to iOS events.
 


### PR DESCRIPTION
make v2 docs links point to 2.x branch instead of master, which doesn't exists and despite github redirects, there were some renaming on iOS template

closes https://github.com/ionic-team/capacitor-docs/pull/373