### PR TITLE
docs: fix typo in privacy manifest file

### DIFF
--- a/docs/main/ios/privacy-manifest.md
+++ b/docs/main/ios/privacy-manifest.md
@@ -53,7 +53,7 @@ Check your app in the *Targets* list.
 
 Click *Create*.
 
-A filed called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
+A file called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
 
 As a sample file here is a `PrivacyInfo.xcprivacy` file that uses the UserDefaults API through its use of the `@capacitor/preferences` plugin.
 

--- a/versioned_docs/version-v4/main/ios/privacy-manifest.md
+++ b/versioned_docs/version-v4/main/ios/privacy-manifest.md
@@ -53,7 +53,7 @@ Check your app in the *Targets* list.
 
 Click *Create*.
 
-A filed called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
+A file called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
 
 As a sample file here is a `PrivacyInfo.xcprivacy` file that uses the UserDefaults API through its use of the `@capacitor/preferences` plugin.
 

--- a/versioned_docs/version-v5/main/ios/privacy-manifest.md
+++ b/versioned_docs/version-v5/main/ios/privacy-manifest.md
@@ -53,7 +53,7 @@ Check your app in the *Targets* list.
 
 Click *Create*.
 
-A filed called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
+A file called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
 
 As a sample file here is a `PrivacyInfo.xcprivacy` file that uses the UserDefaults API through its use of the `@capacitor/preferences` plugin.
 

--- a/versioned_docs/version-v6/main/ios/privacy-manifest.md
+++ b/versioned_docs/version-v6/main/ios/privacy-manifest.md
@@ -53,7 +53,7 @@ Check your app in the *Targets* list.
 
 Click *Create*.
 
-A filed called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
+A file called `PrivacyInfo.xcprivacy` will be created. This file is challenging to create interactively in the Xcode UI so it may be easier to edit it manually by right clicking it and choosing *Open with External Editor*.
 
 As a sample file here is a `PrivacyInfo.xcprivacy` file that uses the UserDefaults API through its use of the `@capacitor/preferences` plugin.
 


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-docs/pull/374