### PR TITLE
installation.md: Add "npm run build" before "npx cap sync" to fix error

### DIFF
--- a/docs/main/getting-started/installation.md
+++ b/docs/main/getting-started/installation.md
@@ -71,9 +71,10 @@ npx cap add ios
 
 ### Sync your web code to your native project
 
-Once you've created your native projects, you can sync your web application to your native project by running the following command.
+Once you've created your native projects, you can build &amp; sync your web application to your native project by running the following commands.
 
 ```bash
+npm run build
 npx cap sync
 ```
 


### PR DESCRIPTION
Hi all!

I noticed that running `npx cap sync` in the Quick Start docs results in the following error:

```
[error] Could not find the web assets directory: ./dist.
        Please create it and make sure it has an index.html file. You can change the path of this
        directory in capacitor.config.json (webDir option). You may need to compile the web assets
        for your app (typically npm run build). More info:
        https://capacitorjs.com/docs/basics/workflow#sync-your-project
```

The docs are missing the `npm run build` command prior to running `npx cap sync`. This PR adds the missing command.

Tested on the latest Capacitor version.