### PR TITLE
docs: Add dependency examples on iOS plugin guide

### DIFF
--- a/docs/plugins/creating-plugins/ios-guide.md
+++ b/docs/plugins/creating-plugins/ios-guide.md
@@ -360,4 +360,38 @@ Returning `nil` will defer to the default Capacitor policy.
 
 ## Advanced configuration
 
-Capacitor iOS plugins are CocoaPods libraries, so to add dependencies, required frameworks or any other advanced configurations you have to edit the `.podspec` file created by the plugin generator, check the [podspec reference](https://guides.cocoapods.org/syntax/podspec.html) to see all possible options.
+Capacitor iOS plugins are both CocoaPods and Swift Package Manager libraries, so to add dependencies, required frameworks or any other advanced configurations you have to edit the `.podspec` for CocoaPods and the `Package.swift` for SPM. Those files were created by the plugin generator.
+Check the [podspec reference](https://guides.cocoapods.org/syntax/podspec.html) to see all possible options for CocoaPods.
+Check the [Package Description](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html) to see all possible options for SPM.
+
+Example `.podspec` dependency to add `FirebaseFirestore` version `11.8.0` or newer but lower than `12.0.0`.
+
+```
+  s.dependency 'Capacitor'
+  s.dependency 'FirebaseFirestore', '~> 11.8'
+```
+
+Example `Package.swift` dependency to add `FirebaseFirestore` version `11.8.0` or newer but lower than `12.0.0`.
+
+```swift
+...
+let package = Package(
+...
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git",  from: "11.8.0")
+    ],
+    targets: [
+        .target(
+            name: "FirebaseFirestorePlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseFirestore", package: "firebase-ios-sdk")
+            ],
+            path: "ios/Plugin")
+    ]
+...
+)
+```

--- a/versioned_docs/version-v6/plugins/creating-plugins/ios-guide.md
+++ b/versioned_docs/version-v6/plugins/creating-plugins/ios-guide.md
@@ -360,4 +360,38 @@ Returning `nil` will defer to the default Capacitor policy.
 
 ## Advanced configuration
 
-Capacitor iOS plugins are CocoaPods libraries, so to add dependencies, required frameworks or any other advanced configurations you have to edit the `.podspec` file created by the plugin generator, check the [podspec reference](https://guides.cocoapods.org/syntax/podspec.html) to see all possible options.
+Capacitor iOS plugins are both CocoaPods and Swift Package Manager libraries, so to add dependencies, required frameworks or any other advanced configurations you have to edit the `.podspec` for CocoaPods and the `Package.swift` for SPM. Those files were created by the plugin generator.
+Check the [podspec reference](https://guides.cocoapods.org/syntax/podspec.html) to see all possible options for CocoaPods.
+Check the [Package Description](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html) to see all possible options for SPM.
+
+Example `.podspec` dependency to add `FirebaseFirestore` version `11.8.0` or newer but lower than `12.0.0`.
+
+```
+  s.dependency 'Capacitor'
+  s.dependency 'FirebaseFirestore', '~> 11.8'
+```
+
+Example `Package.swift` dependency to add `FirebaseFirestore` version `11.8.0` or newer but lower than `12.0.0`.
+
+```swift
+...
+let package = Package(
+...
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "6.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git",  from: "11.8.0")
+    ],
+    targets: [
+        .target(
+            name: "FirebaseFirestorePlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseFirestore", package: "firebase-ios-sdk")
+            ],
+            path: "ios/Plugin")
+    ]
+...
+)
+```


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor-docs/issues/49