### PR TITLE
docs: update the plugin tutorial

### DIFF
--- a/docs/plugins/tutorial/designing-api.md
+++ b/docs/plugins/tutorial/designing-api.md
@@ -108,12 +108,7 @@ import { registerPlugin } from '@capacitor/core';
 
 import type { ScreenOrientationPlugin } from './definitions';
 
-const ScreenOrientation = registerPlugin<ScreenOrientationPlugin>(
-  'ScreenOrientation',
-  {
-    web: () => import('./web').then(m => new m.ScreenOrientationWeb()),
-  },
-);
+const ScreenOrientation = registerPlugin<ScreenOrientationPlugin>('ScreenOrientation');
 
 export * from './definitions';
 export { ScreenOrientation };

--- a/docs/plugins/tutorial/implementing-for-android.md
+++ b/docs/plugins/tutorial/implementing-for-android.md
@@ -15,7 +15,8 @@ Development for the plugin is nearly complete. All that’s left is the Android 
 
 > **Prerequisite:** Familiarize yourself with the <a href="https://capacitorjs.com/docs/android/custom-code" target="_blank">Capacitor Custom Native Android Code documentation</a> before continuing.
 
-Open up the Capacitor application’s Android project in Android Studio by running `npx cap open android`. Expand the **app** module and the **java** folder and right-click on your app’s Java package. Select **New -> Package** from the context menu and create a subpackage named **plugins**. Right-click the **plugins** package and repeat the preceding process to create a subpackage named **ScreenOrientation**.
+Open up the Capacitor application’s Android project in Android Studio by running `npx cap open android`. Expand the **app** module and the **java** folder and right-click on your app’s Java package (the `io.ionic.cap.plugin` package).
+Select **New -> Package** from the context menu and create a subpackage named **plugins**. Right-click the **plugins** package and repeat the preceding process to create a subpackage named **ScreenOrientation**.
 
 Next, right-click the **ScreenOrientation** package and add a new Java file by selecting **New -> Java File** from the context menu. Name this file `ScreenOrientationPlugin.java`. Repeat the process to create a new file named `ScreenOrientation.java`.
 

--- a/docs/plugins/tutorial/implementing-for-web.md
+++ b/docs/plugins/tutorial/implementing-for-web.md
@@ -9,7 +9,7 @@ slug: /plugins/tutorial/web
 
 # Implementing for Web/PWAs
 
-While designing the plugin’s API, we found out that the web already supports screen orientation functionality (except on mobile devices, of course). You might be asking why what would be the purpose for our plugin to have a web implementation...couldn’t you programmatically detect if the user is on the web and use the <a href="https://whatwebcando.today/screen-orientation.html" target="_blank">Screen Orientation Web API</a>, otherwise, use the plugin?
+While designing the plugin’s API, we found out that the web already supports screen orientation functionality (except on mobile devices, of course). You might be asking: "What is the purpose of our plugin having a web implementation? Couldn’t we programmatically detect if the user is on the web and use the <a href="https://whatwebcando.today/screen-orientation.html" target="_blank">Screen Orientation Web API</a>, otherwise, use the plugin?"
 
 The mantra behind Web Native applications is "write once, run anywhere." This applies to plugins as well; developers using Capacitor plugins ought to be able to use the same plugin class and methods and have them implemented for all platforms.
 
@@ -70,17 +70,18 @@ Then implement the remaining methods as part of the `ScreenOrientationWeb` class
   }
 
  async lock(options: OrientationLockOptions): Promise<void> {
+    // See https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1615
     if (
       typeof screen === 'undefined' ||
       !screen.orientation ||
-      !screen.orientation.lock
+      !(screen.orientation as any).lock
     ) {
       throw this.unavailable(
         'ScreenOrientation API not available in this browser',
       );
     }
     try {
-      await screen.orientation.lock(options.orientation);
+      await (screen.orientation as any).lock(options.orientation);
     } catch {
       throw this.unavailable(
         'ScreenOrientation API not available in this browser',


### PR DESCRIPTION
Most of the changes center around making sure the workflow lines up between sections and that the code matches what is required for current versions of Capacitor as the original tutorial was rather old.