### PR TITLE
docs: Update google-maps plugin

### DIFF
--- a/docs/apis/google-maps.md
+++ b/docs/apis/google-maps.md
@@ -1188,6 +1188,18 @@ Array should contain between two and three elements.
 The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
 but the current specification only allows X, Y, and (optionally) Z to be defined.
 
+Note: the type will not be narrowed down to `[number, number] | [number, number, number]` due to
+marginal benefits and the large impact of breaking change.
+
+See previous discussions on the type narrowing:
+- {@link https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21590|Nov 2017}
+- {@link https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/67773|Dec 2023}
+- {@link https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/71441| Dec 2024}
+
+One can use a
+{@link https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates|user-defined type guard that returns a type predicate}
+to determine if a position is a 2D or 3D position.
+
 <code>number[]</code>
 
 


### PR DESCRIPTION
The google-maps had a recently release, that also updated some docs that were missing in the doc page. This PR updates those missing docs.