### PR TITLE
docs: Remove rosetta and ffi related CocoaPods notes

### DIFF
--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -91,18 +91,7 @@ You can install CocoaPods directly with Ruby Gem. To install it, you can run the
 sudo gem install cocoapods
 ```
 
-However, installing CocoaPods this way **will not** work on Apple Silicon Macs. You will need to run CocoaPods through Rosetta enabled. To do this, you can run the following commands.
-
-```bash
-sudo arch -x86_64 gem install ffi
-```
-
-Then, whenever you want to update your application to use a newer version of your web code, you will need to run the following commands.
-
-```bash
-npx cap copy
-arch -x86_64 pod install
-```
+For running without sudo see [CocoaPods sudo-less installation docs](https://guides.cocoapods.org/using/getting-started.html#sudo-less-installation)
 
 ## Android Requirements
 

--- a/docs/main/getting-started/faqs.md
+++ b/docs/main/getting-started/faqs.md
@@ -65,23 +65,3 @@ Short answer, no. The longer answer is that while you can use cloud services lik
 
 Capacitor requires Android 5.1 as well as a WebView version of 60 or higher. If you create an Android 6 or 7 emulator for example, the newest version of the WebView won't be installed, and you'll get a blank white screen. To get around this, you can install a newer Android emulator for testing your application.
 
-## Why am I getting CocoaPods errors on my Apple Silicon Device?
-
-If you installed CocoaPods with `sudo gem install cocoapods` and you're using an Apple Silicon-powered Mac, you might encounter something like this when running `npx cap update`:
-
-```
-[error] Analyzing dependencies
-        /Library/Ruby/Gems/2.6.0/gems/ffi-1.15.3/lib/ffi/library.rb:275: [BUG] Bus Error at 0x0000000000000000
-        ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.arm64e-darwin20]
-```
-
-This is a CocoaPods bug related to `ffi` not installing on Apple Silicon computers.
-We recommend using [Homebrew to install CocoaPods](/main/getting-started/environment-setup.md#homebrew).
-Alternatively, if you have Rosetta installed, you can install `ffi` on a `x86_64` architecture and run `pod install` using the simulated Intel architecture for the first time.
-
-```
-$ sudo arch -x86_64 gem install ffi
-$ arch -x86_64 pod install
-```
-
-After that, running Capacitor should work as expected.

--- a/docs/main/ios/troubleshooting.md
+++ b/docs/main/ios/troubleshooting.md
@@ -67,27 +67,6 @@ Xcode sometimes gets stuck indexing forever. This unfortunate situation looks li
 
 The only solution is to Force Close Xcode (using Activity Monitor) and start it up again.
 
-## Apple Silicon: `ffi` Bus Error
-
-If you installed CocoaPods with `sudo gem install cocoapods` and you're using an Apple Silicon-powered Mac, you might encounter something like this when running `npx cap update`:
-
-```
-[error] Analyzing dependencies
-        /Library/Ruby/Gems/2.6.0/gems/ffi-1.15.3/lib/ffi/library.rb:275: [BUG] Bus Error at 0x0000000000000000
-        ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.arm64e-darwin20]
-```
-
-This is a CocoaPods bug related to `ffi` not installing on Apple Silicon computers.
-We recommend using [Homebrew to install CocoaPods](/main/getting-started/environment-setup.md#homebrew).
-Alternatively, if you have Rosetta installed, you can install `ffi` on a `x86_64` architecture and run `pod install` using the simulated Intel architecture for the first time.
-
-```
-$ sudo arch -x86_64 gem install ffi
-$ arch -x86_64 pod install
-```
-
-After that, running Capacitor should work as expected.
-
 ## CocoaPods: Failed to connect to GitHub
 
 This error can happen on Macs with an old version of openssl and ruby installed, since GitHub


### PR DESCRIPTION
Doesn't seem to be needed anymore