### PR TITLE
docs: update NuxtJS Deep Link setup

### DIFF
--- a/docs/main/guides/deep-links.md
+++ b/docs/main/guides/deep-links.md
@@ -331,11 +331,7 @@ Place the association files under `src/.well-known`. Next, configure the build p
 
 Build then deploy the site.
 
-### NuxtJS
-
-Place the association files under `static/.well-known`. No additional steps are necessary; simply build then deploy the site.
-
-### React
+### NuxtJS & React
 
 Place the association files under `public/.well-known`. No additional steps are necessary; simply build then deploy the site.
 


### PR DESCRIPTION
Since in NuxtJS it should also be the `public/` directory and not `static` - the setup docs for NuxtJS were updated.

Further, since it now is exactly the same as React, the sections were merged.

At least for Nuxt 3.x & 4.x: https://nuxt.com/docs/3.x/guide/directory-structure/public