### PR TITLE
Change the vue deeplink example slug with query parameters

### DIFF
--- a/versioned_docs/version-v7/main/guides/deep-links.md
+++ b/versioned_docs/version-v7/main/guides/deep-links.md
@@ -182,9 +182,7 @@ App.addListener('appUrlOpen', function (event: URLOpenListenerEvent) {
 
   // We only push to the route if there is a slug present
   if (slug) {
-    router.push({
-      path: slug,
-    });
+    router.push({slug);
   }
 });
 ```

--- a/versioned_docs/version-v7/main/guides/deep-links.md
+++ b/versioned_docs/version-v7/main/guides/deep-links.md
@@ -182,7 +182,7 @@ App.addListener('appUrlOpen', function (event: URLOpenListenerEvent) {
 
   // We only push to the route if there is a slug present
   if (slug) {
-    router.push({slug);
+    router.push(slug);
   }
 });
 ```


### PR DESCRIPTION
By changing the router.push(...) to string format the router will also parse the query parameters from the url, like we have on a redirect from keycloak.