### PR TITLE
docs: update camera links

### DIFF
--- a/docs/apis/camera.md
+++ b/docs/apis/camera.md
@@ -1,8 +1,8 @@
 ---
 title: Camera Capacitor Plugin API
 description: The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.
-custom_edit_url: https://github.com/ionic-team/capacitor-plugins/blob/main/camera/README.md
-editApiUrl: https://github.com/ionic-team/capacitor-plugins/blob/main/camera/src/definitions.ts
+custom_edit_url: https://github.com/ionic-team/capacitor-camera/blob/main/README.md
+editApiUrl: https://github.com/ionic-team/capacitor-camera/blob/main/src/definitions.ts
 sidebar_label: Camera
 ---
 

--- a/docs/apis/geolocation.md
+++ b/docs/apis/geolocation.md
@@ -167,10 +167,10 @@ Not available on web.
 
 #### Position
 
-| Prop            | Type                                                                                                                                                                                | Description                                             | Since |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----- |
-| **`timestamp`** | <code>number</code>                                                                                                                                                                 | Creation timestamp for coords                           | 1.0.0 |
-| **`coords`**    | <code>{ latitude: number; longitude: number; accuracy: number; altitudeAccuracy: number \| null; altitude: number \| null; speed: number \| null; heading: number \| null; }</code> | The GPS coordinates along with the accuracy of the data | 1.0.0 |
+| Prop            | Type                                                                                                                                                                                                                                                                                                       | Description                                             | Since |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----- |
+| **`timestamp`** | <code>number</code>                                                                                                                                                                                                                                                                                        | Creation timestamp for coords                           | 1.0.0 |
+| **`coords`**    | <code>{ latitude: number; longitude: number; accuracy: number; altitudeAccuracy: number \| null; altitude: number \| null; speed: number \| null; heading: number \| null; magneticHeading: number \| null; trueHeading: number \| null; headingAccuracy: number \| null; course: number \| null; }</code> | The GPS coordinates along with the accuracy of the data | 1.0.0 |
 
 
 #### PositionOptions

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -74,8 +74,8 @@ const pluginApis = [
     isCore: false,
     isExperimental: false,
     npmScope: '@capacitor',
-    editUrl: 'https://github.com/ionic-team/capacitor-plugins/blob/main/camera/README.md',
-    editApiUrl: 'https://github.com/ionic-team/capacitor-plugins/blob/main/camera/src/definitions.ts',
+    editUrl: 'https://github.com/ionic-team/capacitor-camera/blob/main/README.md',
+    editApiUrl: 'https://github.com/ionic-team/capacitor-camera/blob/main/src/definitions.ts',
   },
   {
     id: 'clipboard',


### PR DESCRIPTION
point to the separate repository for camera plugin

also geolocation was released last week and running `npm run generate-plugin-docs` picked some doc changes