### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,6 +237,7 @@ module.exports = {
     },
   },
   plugins: [
+    'docusaurus-plugin-copy-page-button',
     function (context, options) {
       return {
         name: 'ionic-docs-ads',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@prismicio/client": "^6.4.2",
         "@prismicio/react": "~2.2.0",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-copy-page-button": "^0.8.3",
         "node-fetch": "^3.3.2",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.2.0",
@@ -6753,6 +6754,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.3.tgz",
+      "integrity": "sha512-2/k4H/ePsuZUVv5S91XC2zhnIWLufHzEPTdo/6jYcvonQqHKcLK9vfOp24L5qwMO16VGhHRIEYcEVrXOshxaBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-sass": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@prismicio/client": "^6.4.2",
     "@prismicio/react": "~2.2.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.8.3",
     "node-fetch": "^3.3.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.2.0",


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in docusaurus.config.js
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for Capacitor specifically:
the plugin API and iOS/Android setup pages carry a lot of per-page nuance — permissions, native config, platform quirks. the typical flow for an app dev is reading an API or guide page → wanting to drop just that page into an LLM to scaffold the integration or debug a native build issue. this saves the select-and-clean step and keeps the model grounded in the current API rather than a stale training snapshot.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
