### PR TITLE
docs: link to spm guide

### DIFF
--- a/docs/main/updating/6-0.md
+++ b/docs/main/updating/6-0.md
@@ -42,7 +42,7 @@ Capacitor 6 requires Xcode 15.0+.
 
 ### SPM Support
 
-Converting from using CocoaPods to SPM is covered in the [Swift Package Manager](/main/ios/spm.md) guide.
+Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
 
 ### Register custom plugins
 

--- a/docs/main/updating/6-0.md
+++ b/docs/main/updating/6-0.md
@@ -42,7 +42,7 @@ Capacitor 6 requires Xcode 15.0+.
 
 ### SPM Support
 
-Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
+Converting from using CocoaPods to SPM is covered in the [Swift Package Manager](/main/ios/spm.md) guide.
 
 ### Register custom plugins
 

--- a/versioned_docs/version-v6/main/updating/6-0.md
+++ b/versioned_docs/version-v6/main/updating/6-0.md
@@ -42,7 +42,7 @@ Capacitor 6 requires Xcode 15.0+.
 
 ### SPM Support
 
-Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
+Converting from using CocoaPods to SPM is covered in the [Swift Package Manager](/main/ios/spm.md) guide.
 
 ### Register custom plugins
 

--- a/versioned_docs/version-v7/main/updating/6-0.md
+++ b/versioned_docs/version-v7/main/updating/6-0.md
@@ -42,7 +42,7 @@ Capacitor 6 requires Xcode 15.0+.
 
 ### SPM Support
 
-Converting from using Cocoapods to SPM is a pretty large topic we will cover in a different article, coming soon.
+Converting from using CocoaPods to SPM is covered in the [Swift Package Manager](/main/ios/spm.md) guide.
 
 ### Register custom plugins
 


### PR DESCRIPTION
The Capacitor 6 documentation stated there was SPM information coming soon, so I linked it to the SPM page that exists, which also talks about migration from CocoaPods to SPM (which may not be the same article originally referred in the docs - Idk if we were referring to https://ionic.io/blog/swift-package-manager-and-capacitor but the existed docs page seems better suited)