### PR TITLE
docs: fix location of capacitor-background-runner README.md

### DIFF
--- a/scripts/api-v7.mjs
+++ b/scripts/api-v7.mjs
@@ -47,7 +47,7 @@ const pluginApis = [
     isCore: false,
     isExperimental: false,
     npmScope: '@capacitor',
-    editUrl: 'https://github.com/ionic-team/capacitor-background-runner/blob/2.x/README.md',
+    editUrl: 'https://github.com/ionic-team/capacitor-background-runner/blob/2.x/packages/capacitor-plugin/README.md',
     editApiUrl:
       'https://github.com/ionic-team/capacitor-background-runner/blob/2.x/packages/capacitor-plugin/src/definitions.ts',
   },

--- a/scripts/api.mjs
+++ b/scripts/api.mjs
@@ -49,7 +49,7 @@ const pluginApis = [
     isCore: false,
     isExperimental: false,
     npmScope: '@capacitor',
-    editUrl: 'https://github.com/ionic-team/capacitor-background-runner/blob/main/README.md',
+    editUrl: 'https://github.com/ionic-team/capacitor-background-runner/blob/main/packages/capacitor-plugin/README.md',
     editApiUrl:
       'https://github.com/ionic-team/capacitor-background-runner/blob/main/packages/capacitor-plugin/src/definitions.ts',
   },


### PR DESCRIPTION
point the edit url to the packages/capacitor-plugin/ folder README.md, since that's the one that gets copied to the root, so if we point to the root README.md and users make changes, they will get overwritten on plugin build.