### PR TITLE
docs: add @NativePlugin removal to Capacitor 9 upgrade guide

### DIFF
--- a/docs/main/updating/plugins/9-0.md
+++ b/docs/main/updating/plugins/9-0.md
@@ -6,6 +6,24 @@ slug: /updating/plugins/9-0
 
 # Breaking changes in code
 
+## Android
+
+The `@NativePlugin` annotation and several deprecated permission and activity-result APIs from that era have been removed. For the overall migration pattern, see the [Capacitor 3 plugin migration guide](/updating/plugins/3-0).
+
+| Removed | Replacement |
+| :------ | :---------- |
+| `@NativePlugin` annotation | `@CapacitorPlugin` |
+| `Plugin.saveCall(PluginCall)` | `Bridge.saveCall(PluginCall)` or `PluginCall.setKeepAlive(true)` |
+| `Plugin.getSavedCall()` (no-arg) | `Bridge.getSavedCall(String)` |
+| `Plugin.freeSavedCall()` | `PluginCall.release(Bridge)` |
+| `Plugin.hasDefinedPermissions(String[])` | `Plugin.isPermissionDeclared(String)` |
+| `Plugin.hasPermission(String)` | `Plugin.getPermissionState(String)` / `getPermissionStates()`, or `ActivityCompat.checkSelfPermission(Context, String)` |
+| `Plugin.pluginRequestPermission(String, int)` | `Plugin.requestPermissionForAlias(...)` with `@PermissionCallback` |
+| `Plugin.pluginRequestPermissions(String[], int)` | `Plugin.requestPermissionForAliases(...)` with `@PermissionCallback` |
+| `Plugin.pluginRequestAllPermissions()` | `Plugin.requestAllPermissions(PluginCall, String)` with `@PermissionCallback` |
+| `Plugin.startActivityForResult(PluginCall, Intent, int)` | `Plugin.startActivityForResult(PluginCall, Intent, String)` with `@ActivityCallback` |
+| `Bridge.startActivityForPluginWithResult(PluginCall, Intent, int)` | `Plugin.startActivityForResult(PluginCall, Intent, String)` with `@ActivityCallback` |
+
 # Updating Capacitor to 9.0 in your plugin
 
 :::note

--- a/docs/plugins/creating-plugins/android-guide.md
+++ b/docs/plugins/creating-plugins/android-guide.md
@@ -139,7 +139,7 @@ Before following this section, make sure you've set up your permission aliases a
 
 ### Annotation Changes
 
-> Still using `@NativePlugin`? See the [upgrade guide](/main/updating/plugins/3-0.md#use-the-new-capacitorplugin-annotation) to switch to `@CapacitorPlugin`.
+> The `@NativePlugin` annotation was removed in Capacitor 9. If your plugin still uses it, see the [upgrade guide](/main/updating/plugins/3-0.md#use-the-new-capacitorplugin-annotation) to switch to `@CapacitorPlugin`.
 
 ```diff
  @CapacitorPlugin(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Extends the "Breaking changes in @capacitor/android" section in the "Updating to 9.0" upgrade guide (`docs/main/updating/9-0.md`) with a subsection for the removal of the legacy `@NativePlugin` annotation and its associated deprecated permission/activity-result APIs.

The new subsection documents the annotation removal (with a pointer to the [Capacitor 3 plugin migration guide](/updating/plugins/3-0) for the overall migration pattern) and provides a replacement table for each removed method.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
Capacitor 9 removes the legacy `@NativePlugin` ecosystem (see ionic-team/capacitor#8563 / [RMET-5305](https://outsystemsrd.atlassian.net/browse/RMET-5305)).
Plugin authors and app developers hitting compile errors after upgrading need a place that maps each removed API to its replacement, alongside the rest of the Android deprecated API removals from ionic-team/capacitor#8564.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Content was verified against the actual removals in ionic-team/capacitor#8563 and ionic-team/capacitor#8564 : every removed symbol listed in the guide matches the source changes. Replacements were taken directly from the `@deprecated` javadoc annotations on the removed methods where available, and from the modern equivalents in the same files for the two methods without explicit replacement notes (`Plugin.startActivityForResult(int)` and `Bridge.startActivityForPluginWithResult(int)`).

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
- This PR is currently based on `chore/RMET-5304-cap9-android-deprecated-apis` (#581) since `docs/main/updating/9-0.md` does not yet exist on `main`. Once #581 merges, this PR needs a trivial rebase onto `main`.
- Should be merged together with (or after) ionic-team/capacitor#8558, which lands the actual removals for the 9.0 release.


[RMET-5305]: https://outsystemsrd.atlassian.net/browse/RMET-5305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ