### PR TITLE
docs: update Capacitor 9 docs outside guides and plugin APIs

### DIFF
--- a/docs/cli/commands/run.md
+++ b/docs/cli/commands/run.md
@@ -28,10 +28,6 @@ npx cap run [options] <platform>
 - `--target <id>`: Run on a specific target device
 - `--target-name <name>`: Run on a specific target device by its name (ex: "iPhone 17 Pro", "John's iPhone")
 - `--target-name-sdk-version <version>`: Run on a target device by name with a specific sdk version when using --target-name, (ex: "26.0" for iOS 26 or "35" for Android API 35).  Useful for targets that have the same name but have different OS / SDK versions
-- `--live-reload`: Set live-reload URL via CLI (uses defaults, overrides `server.url` config)
-- `-l`: Shorthand for `--live-reload`
-- `--host <host>`: Configure host for live-reload URL (used with `--live-reload`)
-- `--port <port>`: Configure port for live-reload URL (used with `--live-reload`)
-- `--https`: Use https:// instead of http:// for live-reload URL (used with `--live-reload`)
+- `--url <url>`: Load an external URL in the Web View, useful for live-reload (overrides `server.url` config)
 - `--forwardPorts <port1:port2>`: Automatically run "adb reverse" for better live-reloading support
 

--- a/docs/main/android/index.md
+++ b/docs/main/android/index.md
@@ -16,7 +16,7 @@ Capacitor Android apps are configured and managed through Android Studio.
 
 ## Android Support
 
-API 24+ (Android 7 or later) is supported, which represents around 99% of the Android market. Capacitor requires an Android WebView with Chrome version 60 or later. On Android 7-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView. On Android 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview).
+API 26+ (Android 8 or later) is supported. Capacitor requires an Android WebView with Chrome version 60 or later. On Android 8-9, [Google Chrome](https://play.google.com/store/apps/details?id=com.android.chrome) provides the WebView. On Android 10+ Capacitor uses the [Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview).
 
 ## Adding the Android Platform
 
@@ -46,7 +46,7 @@ Alternatively, you can open Android Studio and import the `android/` directory a
 
 You can either run your app on the command-line or with Android Studio.
 
-> To use an Android Emulator you must use an API 24+ system image. The System WebView does not automatically update on emulators. Physical devices should work as low as API 24 as long as their System WebView is updated.
+> To use an Android Emulator you must use an API 26+ system image. The System WebView does not automatically update on emulators. Physical devices should work as low as API 26 as long as their System WebView is updated.
 
 ### Running on the Command-Line
 

--- a/docs/main/android/setting-target-sdk.md
+++ b/docs/main/android/setting-target-sdk.md
@@ -8,7 +8,7 @@ slug: /android/setting-target-sdk
 All Android applications must specify a target SDK version, or the version of Android that the application is designed to run on. Each year, Google releases updates to the Android operating system and subsequently bumps the version number that applications are required to target. Typically, [this date is August 31st](https://support.google.com/googleplay/android-developer/answer/11926878?hl=en) of each year. Because of this, it is important to keep your application up to date with the latest version of Android. In a Capacitor application, this is done by specifying your target SDK in the `/android/variables.gradle` file.
 
 ```groovy
-targetSdkVersion = 36
+targetSdkVersion = 37
 ```
 
 ## Capacitor Android Requirements

--- a/docs/main/android/setting-target-sdk.md
+++ b/docs/main/android/setting-target-sdk.md
@@ -11,6 +11,10 @@ All Android applications must specify a target SDK version, or the version of An
 targetSdkVersion = 37
 ```
 
+:::note
+Starting with Capacitor 9, AGP 9 infers `targetSdkVersion` from `compileSdkVersion` in your app's `build.gradle` when it isn't set explicitly there, so the two are always equal. `variables.gradle` still defines `targetSdkVersion` for reference and for library modules, but it's no longer read from your app's `defaultConfig`.
+:::
+
 ## Capacitor Android Requirements
 
 In Capacitor, the Android target SDK version is strongly tied to the major version of Capacitor. This means that while you could change the target SDK to a higher version and rebuild your application, there's a very strong likelihood that your application will experience issues not otherwise present. The Capacitor team releases a new major version of Capacitor every year that includes support for the new target SDK version to ensure that applications remain compliant with Google's requirements. For this reason, it is important to keep your application up to date with the latest major version of Capacitor.
@@ -21,6 +25,7 @@ The following table shows the target SDK versions that are supported by Capacito
 
 | Capacitor Android | Target SDK Version |
 | ----------------- | ------------------ |
+| 9.x               | 37                 |
 | 8.x               | 36                 |
 | 7.x               | 35                 |
 | 6.x               | 34                 |

--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -10,13 +10,13 @@ Capacitor has three officially supported application targets: Android, iOS, and 
 
 ## Core Requirements
 
-In order to develop any application with Capacitor, you will need NodeJS 22 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
+In order to develop any application with Capacitor, you will need NodeJS 24 or higher installed. You can install Node by using the installer on [the Node website](https://nodejs.org), using [Volta](https://volta.sh/): a JavaScript tools manager, or installing it with a package manager like [homebrew](https://brew.sh/), or [Chocolatey](https://chocolatey.org/).
 
 Once you have installed Node, open your terminal of choice and type in the following command to make sure node is properly installed
 
 ```bash
 node --version
-# v22.21.1
+# v24.19.0
 ```
 
 With Node installed, you can get started with creating Progressive Web Applications (PWA) with Capacitor.
@@ -34,7 +34,7 @@ Once you've installed the core requirements, as well as Xcode, Xcode Command Lin
 
 ### Xcode
 
-Xcode is Apple's IDE for creating native macOS, iOS, and iPadOS applications. You can install Xcode by [using the Apple App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) on your Mac. Capacitor 8 requires a minimum of Xcode 26.0.
+Xcode is Apple's IDE for creating native macOS, iOS, and iPadOS applications. You can install Xcode by [using the Apple App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) on your Mac. Capacitor 9 requires a minimum of Xcode 27.0.
 
 ### Xcode Command Line Tools
 
@@ -120,16 +120,16 @@ Once you've installed the core requirements, as well as an Android SDK with Andr
 
 ### Android Studio
 
-Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 8 requires a minimum of Android Studio 2025.2.1.
+Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 9 requires a minimum of Android Studio 2025.3.3.
 
 ### Android SDK
 
 Once Android Studio has been installed, you need to install an Android SDK package.
 
-Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 24 or greater.
+Developing Android apps requires some Android SDK packages to be installed. Make sure to install the Android SDK Tools, and a version of the Android SDK Platforms for API 26 or greater.
 
 In Android Studio, open **Tools -> SDK Manager** from the menu and install the platform versions you'd like to test with in the **SDK Platforms** tab:
 
 ![SDK Platforms](/img/v6/docs/android/sdk-platforms.png)
 
-To get started, you only need to install one API version. In the above image, the SDKs for Android 9 (API 28) and Android 10 (API 29) are installed. The latest stable version is Android 16 (API 36).
+To get started, you only need to install one API version. In the above image, the SDKs for Android 9 (API 28) and Android 10 (API 29) are installed. The latest stable version is Android 17 (API 37).

--- a/docs/main/getting-started/faqs.md
+++ b/docs/main/getting-started/faqs.md
@@ -16,8 +16,8 @@ Capacitor can target virtually any device with our official and community platfo
 ### Official Platforms
 
 Capacitor officially supports the following platforms:
-- iOS 15+
-- Android 7+
+- iOS 16+
+- Android 8+
   - Requires Chrome WebView 60+
 - Modern Web Browsers
   - Chrome

--- a/docs/main/guides/live-reload.md
+++ b/docs/main/guides/live-reload.md
@@ -73,5 +73,5 @@ Finally, click the Run button to launch the app and start using Live Reload.
 Alternatively to setting `url` in `capacitor.config.json`, you can set the live reload url directly from the CLI when running the app from the command line:
 
 ```bash
-npx cap run android --url http://192.168.1.68:8100
+npx cap run --url http://192.168.1.68:8100
 ```

--- a/docs/main/guides/live-reload.md
+++ b/docs/main/guides/live-reload.md
@@ -73,5 +73,5 @@ Finally, click the Run button to launch the app and start using Live Reload.
 Alternatively to setting `url` in `capacitor.config.json`, you can set the live reload url directly from the CLI when running the app from the command line:
 
 ```bash
-npx cap run --live-reload --port 8100
+npx cap run android --url http://192.168.1.68:8100
 ```

--- a/docs/main/ios/index.md
+++ b/docs/main/ios/index.md
@@ -15,7 +15,7 @@ Capacitor iOS apps are configured and managed with Xcode and [CocoaPods](https:/
 
 ## iOS Support
 
-iOS 15+ is supported. Xcode 26.0+ is required (see [Environment Setup](/main/getting-started/environment-setup.md#ios-requirements)). Capacitor uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview), not the deprecated [UIWebView](https://developer.apple.com/documentation/uikit/uiwebview).
+iOS 16+ is supported. Xcode 27.0+ is required (see [Environment Setup](/main/getting-started/environment-setup.md#ios-requirements)). Capacitor uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview), not the deprecated [UIWebView](https://developer.apple.com/documentation/uikit/uiwebview).
 
 ## Adding the iOS Platform
 

--- a/docs/main/reference/support-policy.mdx
+++ b/docs/main/reference/support-policy.mdx
@@ -22,6 +22,7 @@ The current status of each Capacitor version is:
 
 | Version |     Status     |     Released     | Maintenance Ends  | Ext. Support Ends |
 | :-----: | :------------: | :--------------: | :---------------: | :---------------: |
+|   v9    |  Unreleased    |        TBD        |        TBD        |        TBD        |
 |   v8    |   **Active**   | December 8, 2025 |        TBD        |        TBD        |
 |   v7    | Extended Support | January 20, 2025 |   June 8, 2026    |    Dec 8, 2026    |
 |   v6    | End of Support |  April 15, 2024  |   July 20, 2025   | January 20, 2026  |
@@ -40,6 +41,7 @@ The Capacitor team has compiled a set of recommendations for using the Capacitor
 
 | Capacitor | Minimum Node version | Minimum Xcode version | Minimum Android Studio version |
 | :-------: | :------------------: | :-------------------: | :----------------------------: |
+|    v9     |          24          |         27.0          |            2025.3.3            |
 |    v8     |          22          |         26.0          |            2025.2.1            |
 |    v7     |          20          |         16.0          |            2024.2.1            |
 |    v6     |          18          |         15.0          |            2023.1.1            |
@@ -53,6 +55,7 @@ Each Capacitor version sets a minimum version for each of its supported platform
 
 | Capacitor | Minimum iOS version | Minimum Android version |
 | :-------: | :-----------------: | :---------------------: |
+|    v9     |        16.0         |      8.0 (API 26)       |
 |    v8     |        15.0         |      7.0 (API 24)       |
 |    v7     |        14.0         |      6.0 (API 23)       |
 |    v6     |        13.0         |      5.1 (API 22)       |


### PR DESCRIPTION
## Description

Updates Capacitor 9 documentation that falls outside the app/plugin migration guides and the auto-generated plugin API pages:

- `docs/cli/commands/run.md` and `docs/main/guides/live-reload.md`: replace the removed `--live-reload`/`-l`/`--host`/`--port`/`--https` flags with the new `--url` flag (verified directly against the CLI's current option list on the `next` branch)
- `docs/main/ios/index.md`: iOS 15+ / Xcode 26.0+ → iOS 16+ / Xcode 27.0+
- `docs/main/android/index.md`: API 24+ → API 26+ (both the general support statement and the emulator note), keeping the Chrome-vs-System-WebView distinction accurate for the new floor (Android 8-9 vs 10+)
- `docs/main/android/setting-target-sdk.md`: example `targetSdkVersion` 36 → 37
- `docs/main/getting-started/environment-setup.md`: Node 22 → 24, Xcode 26.0 → 27.0, Android Studio 2025.2.1 → 2025.3.3, minimum installable SDK API 24 → 26, latest stable Android 16 (API 36) → Android 17 (API 37)
- `docs/main/reference/support-policy.mdx`: added a `v9` row to all three tables (release status, compatibility recommendations, minimum supported platforms), marked `Unreleased`/TBD where there's no public date yet

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

`docs/main` now represents the unreleased Capacitor 9 (`next`), but several reference pages still described Capacitor 8 minimums and the old live-reload CLI flags. These are locked-in facts already shipped in the `next` branch (Node/iOS/Android floors, the `--url` flag), so keeping the docs stale would actively mislead anyone testing against Capacitor 9 alpha.

Internal Jira reference: https://outsystemsrd.atlassian.net/browse/RMET-5322

## Tests or Reproductions

Every changed value was verified against the actual Capacitor 9 `next` branch (CLI option list, `variables.gradle`, `--version` outputs) rather than inferred, and cross-checked with the internal System Requirements doc for the platform floors. Verified `npm run build` (Docusaurus) succeeds with no broken links or routes.

Note: unlike the other changes, the `support-policy.mdx` `v9` row records values that are still moving pre-GA (e.g. Xcode 27 is in beta at the time of writing). Decided to add it now anyway and revisit if it drifts before GA, rather than waiting until release like previous majors did.

## Screenshots / Media

N/A

## Platforms Affected
- [x] Android
- [x] iOS
- [ ] Web
