### PR TITLE
docs: help Cap 8 readers find live-update options beyond the exclusivity claim

### DIFF
--- a/docs/main/guides/ci-cd.md
+++ b/docs/main/guides/ci-cd.md
@@ -48,4 +48,4 @@ To use it in this way, use webhooks to send built assets to Appflow on each comm
 
 ## Other Mobile CI/CD Options
 
-There are other services for Mobile CI/CD, though none focused on Capacitor. Whichever CI/CD service you prefer, Capacitor can integrate with it as Capacitor apps are just native apps. However, for remote live updates of Capacitor apps, [Appflow](https://ionic.io/appflow) is the only service with this feature.
+There are other services for Mobile CI/CD, though none focused on Capacitor. Whichever CI/CD service you prefer, Capacitor can integrate with it as Capacitor apps are just native apps. For remote live updates of the web layer, Appflow is Ionic's official option. Community live-update plugins also exist, including `@capgo/capacitor-updater`.

--- a/docs/main/guides/deploying-updates.md
+++ b/docs/main/guides/deploying-updates.md
@@ -39,3 +39,5 @@ Appflow powers major consumer and enterprise apps with hundreds of millions of u
 And, because the team behind Appflow works closely with the Capacitor team, Appflow is optimized to work best with Capacitor.
 
 Appflow is free to get started and uses the same Ionic account you may have used in the past. To get started, visit [useappflow.com](https://useappflow.com/) or browse the [documentation](https://ionicframework.com/docs/appflow) to learn more about how Appflow works.
+
+Community live-update plugins also exist, including [`@capgo/capacitor-updater`](https://github.com/Cap-go/capacitor-updater).

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -28,3 +28,8 @@ Check out the [Capawesome Blog](https://capawesome.io/blog/) or [Twitter](https:
 Capacitor has support for most Cordova plugins, so developers can use the [hundreds of existing Cordova plugins](https://cordova.apache.org/plugins/) in their Capacitor apps. While certain Cordova plugins are [not compatible](/plugins/cordova.md#known-incompatible-plugins) with Capacitor, most are, so it's worth trying one if there's no existing Capacitor-specific plugin available.
 
 Also see the [`@awesome-cordova-plugins` Community](https://github.com/danielsogl/awesome-cordova-plugins) plugins for a list of primarily Cordova plugins with convenient wrappers to make them easier to use in your apps. Feel free to use the `@awesome-cordova-plugins` Community wrappers or simply use the list as a reference for quality Cordova plugins.
+
+## Capgo
+
+The [Capgo](https://github.com/Cap-go) GitHub org maintains Capacitor plugins used by the community.
+Browse the catalog at [capgo.app/plugins](https://capgo.app/plugins/) or the [Cap-go GitHub org](https://github.com/Cap-go).

--- a/versioned_docs/version-v8/main/guides/ci-cd.md
+++ b/versioned_docs/version-v8/main/guides/ci-cd.md
@@ -48,4 +48,4 @@ To use it in this way, use webhooks to send built assets to Appflow on each comm
 
 ## Other Mobile CI/CD Options
 
-There are other services for Mobile CI/CD, though none focused on Capacitor. Whichever CI/CD service you prefer, Capacitor can integrate with it as Capacitor apps are just native apps. However, for remote live updates of Capacitor apps, [Appflow](https://ionic.io/appflow) is the only service with this feature.
+There are other services for Mobile CI/CD, though none focused on Capacitor. Whichever CI/CD service you prefer, Capacitor can integrate with it as Capacitor apps are just native apps. For remote live updates of the web layer, Appflow is Ionic's official option. Community live-update plugins also exist, including `@capgo/capacitor-updater`.

--- a/versioned_docs/version-v8/main/guides/deploying-updates.md
+++ b/versioned_docs/version-v8/main/guides/deploying-updates.md
@@ -39,3 +39,5 @@ Appflow powers major consumer and enterprise apps with hundreds of millions of u
 And, because the team behind Appflow works closely with the Capacitor team, Appflow is optimized to work best with Capacitor.
 
 Appflow is free to get started and uses the same Ionic account you may have used in the past. To get started, visit [useappflow.com](https://useappflow.com/) or browse the [documentation](https://ionicframework.com/docs/appflow) to learn more about how Appflow works.
+
+Community live-update plugins also exist, including [`@capgo/capacitor-updater`](https://github.com/Cap-go/capacitor-updater).

--- a/versioned_docs/version-v8/plugins/community.md
+++ b/versioned_docs/version-v8/plugins/community.md
@@ -28,3 +28,8 @@ Check out the [Capawesome Blog](https://capawesome.io/blog/) or [Twitter](https:
 Capacitor has support for most Cordova plugins, so developers can use the [hundreds of existing Cordova plugins](https://cordova.apache.org/plugins/) in their Capacitor apps. While certain Cordova plugins are [not compatible](/plugins/cordova.md#known-incompatible-plugins) with Capacitor, most are, so it's worth trying one if there's no existing Capacitor-specific plugin available.
 
 Also see the [`@awesome-cordova-plugins` Community](https://github.com/danielsogl/awesome-cordova-plugins) plugins for a list of primarily Cordova plugins with convenient wrappers to make them easier to use in your apps. Feel free to use the `@awesome-cordova-plugins` Community wrappers or simply use the list as a reference for quality Cordova plugins.
+
+## Capgo
+
+The [Capgo](https://github.com/Cap-go) GitHub org maintains Capacitor plugins used by the community.
+Browse the catalog at [capgo.app/plugins](https://capgo.app/plugins/) or the [Cap-go GitHub org](https://github.com/Cap-go).


### PR DESCRIPTION
## Why this matters for Ionic customers

A growing set of Capacitor customers are on Capacitor 8 and still need remote live updates. Some teams are planning what comes next for their delivery pipeline.

Those customers land on the Capacitor guides. Today `ci-cd.md` tells them Appflow is the **only** service that can do remote live updates. That sentence is inaccurate, and it leaves people who must move (or who already use a community plugin) with a dead end in the official docs.

This PR is meant to make that path clearer for **your** readers, without changing how Appflow is presented as Ionic’s official option.

## What stays the same

- All existing Appflow sections, CTAs, and get-started copy
- Appflow as Ionic’s official live-update / Mobile DevOps recommendation

## What changes

1. **`ci-cd` (main + v8)** — replace only the exclusivity sentence so customers are not told Appflow is the sole option.
2. **`deploying-updates` (main + v8)** — leave the Appflow guide intact; add one short factual sentence after it.
3. **`plugins/community` (main + v8)** — add a Capgo subsection next to the other community plugin orgs already listed, so customers who need a community option can find it from the docs they already trust.

## Ask

Happy to trim further (for example Capgo named only under `plugins/community`) if that is easier for maintainers to ship.
