### PR TITLE
docs: Update Android Studio requirement for Cap 9

### DIFF
--- a/docs/main/getting-started/environment-setup.md
+++ b/docs/main/getting-started/environment-setup.md
@@ -120,7 +120,7 @@ Once you've installed the core requirements, as well as an Android SDK with Andr
 
 ### Android Studio
 
-Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 9 requires a minimum of Android Studio 2025.3.3.
+Android Studio is Google's IDE for creating native Android applications. You can install Android Studio by going to the [Android Studio download page](https://developer.android.com/studio). Capacitor 9 requires a minimum of Android Studio 2026.1.1.
 
 ### Android SDK
 

--- a/docs/main/reference/support-policy.mdx
+++ b/docs/main/reference/support-policy.mdx
@@ -41,7 +41,7 @@ The Capacitor team has compiled a set of recommendations for using the Capacitor
 
 | Capacitor | Minimum Node version | Minimum Xcode version | Minimum Android Studio version |
 | :-------: | :------------------: | :-------------------: | :----------------------------: |
-|    v9     |          24          |         27.0          |            2025.3.3            |
+|    v9     |          24          |         27.0          |            2026.1.1            |
 |    v8     |          22          |         26.0          |            2025.2.1            |
 |    v7     |          20          |         16.0          |            2024.2.1            |
 |    v6     |          18          |         15.0          |            2023.1.1            |

--- a/docs/main/updating/9-0.md
+++ b/docs/main/updating/9-0.md
@@ -109,7 +109,7 @@ The following guide describes how to upgrade your Capacitor 8 Android project to
 
 ### Upgrade Android Studio
 
-Capacitor 9 requires Android Studio 2025.3.3 or newer.
+Capacitor 9 requires Android Studio 2026.1.1 or newer.
 
 Once it's updated, Android Studio can assist with some of the updates related to gradle. To start, run `Tools -> AGP Upgrade Assistant` and choose `9.2.1` as the version to update on dropdown. Then click `Run selected steps`.
 


### PR DESCRIPTION
Update the minimum Android Studio version for Capacitor 9 from 2025.3.3 to 2026.1.1 (Quail 1) across the environment setup guide, the v9 upgrade guide, and the compatibility table. According to [Android documentation](https://developer.android.com/build/releases/about-agp#android_gradle_plugin_and_android_studio_compatibility), 2025.3.3 AGP version caps at 9.1, while Capacitor 9 requires AGP 9.2.1.

The earliest technically-compatible release is 2025.3.4, but we're pointing to 2026.1.1 instead to match the existing v8 precedent (which pointed to Otter 2025.2.1 rather than the earlier-compatible Narwhal 3/4 feature drops), i.e. recommending the first release of the next major Android Studio line rather than a late feature-drop patch of the previous one.