### PR TITLE
docs: cover AGP 9 gradle.properties and build.gradle version declarations

### DIFF
--- a/docs/main/updating/9-0.md
+++ b/docs/main/updating/9-0.md
@@ -134,8 +134,6 @@ AGP 9 changed the defaults of several `gradle.properties` flags, and the AGP Upg
 - android.newDsl=false
 ```
 
-Keep `android.useAndroidX=true`. It matches the AGP 9 default and is therefore redundant, but it is harmless and the Assistant leaves it in place too.
-
 ### Update Android Project Variables
 
 In your `variables.gradle` file, update your values to the following new minimums
@@ -201,6 +199,8 @@ apply plugin: 'com.android.application'
 
 android {
 ```
+
+Those are the variables the Capacitor template declares. If your app references any other variable from `variables.gradle`, for example a dependency version used by a local plugin, declare it here too.
 
 ### Migrate core-ktx to core
 

--- a/docs/main/updating/9-0.md
+++ b/docs/main/updating/9-0.md
@@ -115,6 +115,27 @@ Once it's updated, Android Studio can assist with some of the updates related to
 
 ![APG Upgrade Assistant](../../../static/img/v6/docs/android/agp-upgrade-assistant.png)
 
+### Clean up gradle.properties
+
+AGP 9 changed the defaults of several `gradle.properties` flags, and the AGP Upgrade Assistant writes them back explicitly so your build keeps the AGP 8 behavior. A Capacitor app needs none of them: most are deprecated and will be removed in AGP 10, and a couple actively break a Capacitor 9 build (`android.builtInKotlin=false` turns off the Kotlin support that AGP 9 now bundles, and `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`). Remove them:
+
+```diff
+# gradle.properties
+
+- android.defaults.buildfeatures.resvalues=true
+- android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+- android.enableAppCompileTimeRClass=false
+- android.usesSdkInManifest.disallowed=false
+- android.uniquePackageNames=false
+- android.dependency.useConstraints=true
+- android.r8.strictFullModeForKeepRules=false
+- android.r8.optimizedResourceShrinking=false
+- android.builtInKotlin=false
+- android.newDsl=false
+```
+
+Keep `android.useAndroidX=true`. It matches the AGP 9 default and is therefore redundant, but it is harmless and the Assistant leaves it in place too.
+
 ### Update Android Project Variables
 
 In your `variables.gradle` file, update your values to the following new minimums
@@ -162,6 +183,23 @@ buildTypes {
 +       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
 }
+```
+
+### Declare dependency versions in your app's build.gradle
+
+Your `app/build.gradle` references version variables that are declared in the root project's `variables.gradle`, and relies on Gradle walking up the project hierarchy to resolve them. That implicit lookup is deprecated in Gradle 9.6 and becomes an error in Gradle 10, so declare them explicitly at the top of the file:
+
+```diff
+apply plugin: 'com.android.application'
+
++ def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion
++ def androidxCoordinatorLayoutVersion = rootProject.ext.androidxCoordinatorLayoutVersion
++ def coreSplashScreenVersion = rootProject.ext.coreSplashScreenVersion
++ def junitVersion = rootProject.ext.junitVersion
++ def androidxJunitVersion = rootProject.ext.androidxJunitVersion
++ def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
+
+android {
 ```
 
 ### Migrate core-ktx to core


### PR DESCRIPTION
## Description

Two sections added to the Capacitor 9 app upgrade guide (`updating/9-0`), both under Android:

**Clean up gradle.properties**, placed right after "Upgrade Android Studio". That section tells readers to run `Tools -> AGP Upgrade Assistant`, which is precisely what writes the AGP 8 compatibility flags into `gradle.properties`. The guide recommended the step without saying to clean up after it, and a couple of those flags break a Capacitor 9 build (`android.builtInKotlin=false` disables the Kotlin support AGP 9 bundles, `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`).

**Declare dependency versions in your app's build.gradle**, covering the six explicit `def` declarations that replace the implicit parent project property lookup. That lookup is deprecated in Gradle 9.6 and becomes an error in Gradle 10. The block matches the one in the Capacitor 9 Android template.

The topics the guide already covered (`jcenter()`, the ProGuard file rename, `targetSdkVersion`, built-in Kotlin) are unchanged.

Both changes are also handled automatically by `cap migrate` in ionic-team/capacitor#8584, so the manual steps here mirror what the CLI does.