### PR TITLE
docs: add Clean up gradle.properties for Cap 9 plugin migration

### DIFF
--- a/docs/main/updating/plugins/9-0.md
+++ b/docs/main/updating/plugins/9-0.md
@@ -125,7 +125,7 @@ If your plugin is SPM compatible, also remove the unconditional `Cordova` produc
 
 ### Clean up gradle.properties
 
-AGP 9 changed the defaults of several `gradle.properties` flags, and the AGP Upgrade Assistant writes them back explicitly so your build keeps the AGP 8 behavior. A Capacitor app needs none of them: most are deprecated and will be removed in AGP 10, and a couple actively break a Capacitor 9 build (`android.builtInKotlin=false` turns off the Kotlin support that AGP 9 now bundles, and `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`). Remove them:
+AGP 9 changed the defaults of several `gradle.properties` flags, and the AGP Upgrade Assistant writes them back explicitly so your build keeps the AGP 8 behavior. A Capacitor plugin needs none of them: most are deprecated and will be removed in AGP 10, and a couple actively break a Capacitor 9 build (`android.builtInKotlin=false` turns off the Kotlin support that AGP 9 now bundles, and `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`). Remove them:
 
 ```diff
 # gradle.properties

--- a/docs/main/updating/plugins/9-0.md
+++ b/docs/main/updating/plugins/9-0.md
@@ -123,6 +123,25 @@ If your plugin is SPM compatible, also remove the unconditional `Cordova` produc
     ]
 ```
 
+### Clean up gradle.properties
+
+AGP 9 changed the defaults of several `gradle.properties` flags, and the AGP Upgrade Assistant writes them back explicitly so your build keeps the AGP 8 behavior. A Capacitor app needs none of them: most are deprecated and will be removed in AGP 10, and a couple actively break a Capacitor 9 build (`android.builtInKotlin=false` turns off the Kotlin support that AGP 9 now bundles, and `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`). Remove them:
+
+```diff
+# gradle.properties
+
+- android.defaults.buildfeatures.resvalues=true
+- android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+- android.enableAppCompileTimeRClass=false
+- android.usesSdkInManifest.disallowed=false
+- android.uniquePackageNames=false
+- android.dependency.useConstraints=true
+- android.r8.strictFullModeForKeepRules=false
+- android.r8.optimizedResourceShrinking=false
+- android.builtInKotlin=false
+- android.newDsl=false
+```
+
 ### Update Android Plugin Variables
 
 In your `build.gradle` file, update the following package versions:


### PR DESCRIPTION
jcenter removal and proguard file name changes were already there, only the gradle.properties was missing